### PR TITLE
Turn off `force_latest_compatible_version` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,19 +75,21 @@ jobs:
           skip: Pkg, TOML
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        with:
+          force_latest_compatible_version: true
 ```
 
 The action requires Julia to be installed, so must occur after `setup-julia`. It runs just
 before `julia-buildpkg` so that Resolver.jl creates a Manifest.toml with minimal versions before installing packages.
 
-In this example, we test both `deps` (direct dependencies only) and `alldeps` (deps + weakdeps) scenarios. 
+In this example, we test both `deps` (direct dependencies only) and `alldeps` (deps + weakdeps) scenarios.
 
 The `skip:` input says that we should not attempt to downgrade `Pkg` or `TOML`.
 
 ## Downgrade Modes
 
 - **`deps`**: Minimize only your direct dependencies (recommended for most packages)
-- **`alldeps`**: Minimize direct dependencies and weak dependencies 
+- **`alldeps`**: Minimize direct dependencies and weak dependencies
 - **`all`**: Minimize all packages (may test issues in transitive dependencies)
 
 **Recommendation**: Use `deps` mode for most packages as it focuses on testing your actual compat bounds without being affected by issues in transitive dependencies that you can't control.


### PR DESCRIPTION
In https://github.com/JuliaGeometry/MeshIntegrals.jl/pull/205, I realized that `force_latest_compatible_version` needs to be turned off because CompatHelper.jl PRs fail otherwise. See https://github.com/JuliaGeometry/MeshIntegrals.jl/pull/205#issuecomment-3365140501 for more details.