### PR TITLE
Ensure correct Manifest.toml is used in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,35 @@ before `julia-buildpkg` so that Resolver.jl creates a Manifest.toml with minimal
 
 In this example, we test both `deps` (direct dependencies only) and `alldeps` (deps + weakdeps) scenarios.
 
+### Julia versions before 1.12
+
+On Julia `< 1.12`, `Pkg.test` may still re-resolve package versions for split test environments
+(for example when using both `Project.toml` and `test/Project.toml`), even with
+`allow_reresolve: false` in `julia-actions/julia-runtest`.
+
+For strict lower-bound testing on Julia `< 1.12`, run tests manually from the locked test
+environment instead of using `julia-actions/julia-runtest`:
+
+```yaml
+- uses: julia-actions/julia-downgrade-compat@v2
+  with:
+    skip: LinearAlgebra,Printf,SparseArrays,DelimitedFiles,Test
+    projects: .,test
+    mode: forcedeps
+- name: Run tests
+  run: |
+    julia --project=test --color=yes -e '
+      import Pkg
+      Pkg.develop(Pkg.PackageSpec(path=pwd()))
+      Pkg.instantiate()
+      Pkg.status(; mode=Pkg.PKGMODE_MANIFEST)
+      include("test/runtests.jl")
+    '
+```
+
+For Julia `>= 1.12`, using `julia-actions/julia-runtest` with
+`allow_reresolve: false` and `force_latest_compatible_version: false` is recommended.
+
 When possible, run the action on the same Julia version that you pass as `julia_version`.
 Cross-runtime resolution may fail; matching runtime and target version is recommended and the default for `julia_version`.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ minimal versions and fail if your compat bounds are too low.
     skip: ''
 
     # Comma-separated list of Julia projects to resolve.
-    # Example: ., test, docs
+    # Example: ., test
     # Default: .
     projects: '.'
 

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -1,4 +1,5 @@
 using TOML
+using Pkg
 
 ignore_pkgs = filter(!isempty, map(strip, split(ARGS[1], ",")))
 dirs = filter(!isempty, map(strip, split(ARGS[2], ",")))
@@ -238,7 +239,7 @@ This is needed because the main package is excluded from resolution
 (it's a local source), but the manifest needs to include it for
 workspace projects to work correctly.
 """
-function add_main_package_to_manifest(manifest_file::String, main_project_file::String)
+function add_main_package_to_manifest(manifest_file::String, main_project_file::String; path::String = ".")
     if !isfile(manifest_file)
         @warn "Manifest file not found: $manifest_file"
         return
@@ -262,7 +263,7 @@ function add_main_package_to_manifest(manifest_file::String, main_project_file::
     # Build the entry for the main package
     entry_lines = String[]
     push!(entry_lines, "[[deps.$pkg_name]]")
-    push!(entry_lines, "path = \".\"")
+    push!(entry_lines, "path = \"$path\"")
     push!(entry_lines, "uuid = \"$pkg_uuid\"")
     if pkg_version !== nothing
         push!(entry_lines, "version = \"$pkg_version\"")
@@ -281,6 +282,34 @@ function add_main_package_to_manifest(manifest_file::String, main_project_file::
     end
 
     @info "Added main package $pkg_name to manifest"
+end
+
+"""
+    set_manifest_project_hash(manifest_file, project_file)
+
+Update `project_hash` in `manifest_file` so it matches what Pkg expects for
+`project_file`. This avoids spurious "project dependencies changed" warnings
+and test-time re-resolution in downstream actions.
+"""
+function set_manifest_project_hash(manifest_file::String, project_file::String)
+    if !isfile(manifest_file)
+        @warn "Manifest file not found: $manifest_file"
+        return
+    end
+    if !isfile(project_file)
+        @warn "Project file not found: $project_file"
+        return
+    end
+
+    manifest = TOML.parsefile(manifest_file)
+    env = Pkg.Types.EnvCache(project_file)
+    manifest["project_hash"] = string(Pkg.Types.workspace_resolve_hash(env))
+
+    open(manifest_file, "w") do io
+        TOML.print(io, manifest)
+    end
+
+    @info "Updated project_hash in $manifest_file to match $project_file"
 end
 
 """
@@ -557,13 +586,23 @@ if do_merge
     # Copy manifest to main project directory
     merged_manifest = joinpath(merged_dir, "Manifest.toml")
     main_manifest = joinpath(main_dir, "Manifest.toml")
+    test_manifest = joinpath(test_dir, "Manifest.toml")
     if isfile(merged_manifest)
         cp(merged_manifest, main_manifest; force = true)
         @info "Copied merged manifest to $main_manifest"
 
+        cp(merged_manifest, test_manifest; force = true)
+        @info "Copied merged manifest to $test_manifest"
+
         # Add the main package itself to the manifest as a path dependency
         # This is needed for workspace projects where the test project depends on the main package
-        add_main_package_to_manifest(main_manifest, main_project_file)
+        add_main_package_to_manifest(main_manifest, main_project_file; path = ".")
+        add_main_package_to_manifest(test_manifest, main_project_file; path = "..")
+
+        # Ensure each manifest has the project hash corresponding to the project
+        # that will consume it (main root and test environment respectively).
+        set_manifest_project_hash(main_manifest, main_project_file)
+        set_manifest_project_hash(test_manifest, test_project_file)
     end
 
     # For forcedeps mode, verify lower bounds for both projects

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -303,7 +303,16 @@ function set_manifest_project_hash(manifest_file::String, project_file::String)
 
     manifest = TOML.parsefile(manifest_file)
     env = Pkg.Types.EnvCache(project_file)
-    manifest["project_hash"] = string(Pkg.Types.workspace_resolve_hash(env))
+
+    resolve_hash = if isdefined(Pkg.Types, :workspace_resolve_hash)
+        Pkg.Types.workspace_resolve_hash(env)
+    elseif isdefined(Pkg.Types, :project_resolve_hash)
+        Pkg.Types.project_resolve_hash(env.project)
+    else
+        error("Could not compute project hash: no supported Pkg.Types hash API found")
+    end
+
+    manifest["project_hash"] = string(resolve_hash)
 
     open(manifest_file, "w") do io
         TOML.print(io, manifest)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,17 @@ using Pkg
 
 downgrade_jl = joinpath(dirname(@__DIR__), "downgrade.jl")
 
+function expected_project_hash(project_file::String)
+    env = Pkg.Types.EnvCache(project_file)
+    if isdefined(Pkg.Types, :workspace_resolve_hash)
+        return string(Pkg.Types.workspace_resolve_hash(env))
+    elseif isdefined(Pkg.Types, :project_resolve_hash)
+        return string(Pkg.Types.project_resolve_hash(env.project))
+    else
+        error("Could not compute expected project hash for tests")
+    end
+end
+
 @testset "julia-downgrade-compat resolver tests" begin
     @testset "simple resolver test" begin
         mktempdir() do dir
@@ -233,12 +244,8 @@ downgrade_jl = joinpath(dirname(@__DIR__), "downgrade.jl")
                 @test !isempty(deps_Test)
 
                 # Verify project hashes match what Pkg expects for each project
-                root_hash_expected = string(Pkg.Types.workspace_resolve_hash(
-                    Pkg.Types.EnvCache(joinpath(dir, "Project.toml")),
-                ))
-                test_hash_expected = string(Pkg.Types.workspace_resolve_hash(
-                    Pkg.Types.EnvCache(joinpath(dir, "test", "Project.toml")),
-                ))
+                root_hash_expected = expected_project_hash(joinpath(dir, "Project.toml"))
+                test_hash_expected = expected_project_hash(joinpath(dir, "test", "Project.toml"))
                 @test manifest["project_hash"] == root_hash_expected
                 @test test_manifest["project_hash"] == test_hash_expected
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -209,10 +209,13 @@ downgrade_jl = joinpath(dirname(@__DIR__), "downgrade.jl")
 
                 # Verify Manifest.toml was created
                 @test isfile("Manifest.toml")
+                @test isfile(joinpath("test", "Manifest.toml"))
 
                 # Parse the manifest
                 manifest = TOML.parsefile("Manifest.toml")
                 deps = manifest["deps"]
+                test_manifest = TOML.parsefile(joinpath("test", "Manifest.toml"))
+                test_deps = test_manifest["deps"]
 
                 # Verify TestPackage is in the manifest as a path dependency
                 deps_TestPackage = get(deps, "TestPackage", [])
@@ -220,9 +223,24 @@ downgrade_jl = joinpath(dirname(@__DIR__), "downgrade.jl")
                 @test deps_TestPackage[1]["path"] == "."
                 @test deps_TestPackage[1]["uuid"] == "598b003f-0677-49cf-8d2a-39b1658b755a"
 
+                # Verify TestPackage is present in test manifest with test-relative path
+                test_deps_TestPackage = get(test_deps, "TestPackage", [])
+                @test !isempty(test_deps_TestPackage)
+                @test test_deps_TestPackage[1]["path"] == ".."
+
                 # Verify Test stdlib is in the manifest
                 deps_Test = get(deps, "Test", [])
                 @test !isempty(deps_Test)
+
+                # Verify project hashes match what Pkg expects for each project
+                root_hash_expected = string(Pkg.Types.workspace_resolve_hash(
+                    Pkg.Types.EnvCache(joinpath(dir, "Project.toml")),
+                ))
+                test_hash_expected = string(Pkg.Types.workspace_resolve_hash(
+                    Pkg.Types.EnvCache(joinpath(dir, "test", "Project.toml")),
+                ))
+                @test manifest["project_hash"] == root_hash_expected
+                @test test_manifest["project_hash"] == test_hash_expected
 
                 # Verify the test/Project.toml was restored (still has sources section)
                 test_project = TOML.parsefile("test/Project.toml")


### PR DESCRIPTION
I noticed there is still another problem with merging the main and test project. Looking, e.g., at [this CI log](https://github.com/NumericalMathematics/PositiveIntegrators.jl/actions/runs/22450922652/job/65018830678?pr=168), we can see that when running the tests not the same downgraded package versions are used than after doing the downgrade (e.g. Aqua.jl is downgraded correctly to [v0.8.0](https://github.com/NumericalMathematics/PositiveIntegrators.jl/actions/runs/22450922652/job/65018830678?pr=168#step:6:349), but tests report to use [v0.8.14](https://github.com/NumericalMathematics/PositiveIntegrators.jl/actions/runs/22450922652/job/65018830678?pr=168#step:8:63)). The action creates the correct Manifest.toml, but it is not correctly picked up by julia-runtests. I also tried copying the Manifest.toml first to test/, but this doesn't change anything. Then I tried to copy the Manifest.toml to test/ and not using julia-runtest, but rather manually executing the tests by using this code in the action yaml file:
```yaml
      - uses: julia-actions/julia-downgrade-compat@v2
        with:
          skip: LinearAlgebra,SparseArrays,Statistics,Test
          projects: ., test
          mode: forcedeps
      - name: Lock test manifest to downgraded one
        run: cp Manifest.toml test/Manifest.toml
      - name: Run tests with locked versions
        run: |
          julia --project=test --color=yes -e '
            import Pkg
            Pkg.develop(Pkg.PackageSpec(path=pwd()))
            Pkg.instantiate()
            Pkg.status()
            include("test/runtests.jl")
          '
```
This looks good and the correct versions are used, see [here](https://github.com/NumericalMathematics/PositiveIntegrators.jl/actions/runs/22481042059/job/65119069015?pr=168#step:8:381). However, I think this solution is not very elegant and I would prefer to rely on julia-actions/julia-buildpkg and julia-actions/julia-runtest instead of manually running tests. So I asked AI to help and this PR is what it came up with. I'm not sure if this works, but I will try to set up a test running the downgrade action against this PR to check. I put this into draft mode until I figured out if this fixes the issue.

Update: Seems to [work fine](https://github.com/NumericalMathematics/PositiveIntegrators.jl/actions/runs/22485726904/job/65134728510?pr=168), but only on julia v1.12 because it uses `Pkg.Types.workspace_resolve_hash`, which was introduced in v1.12.

Update 2: Using `project_resolve_hash` to try to make it work also on julia v1.10 does not seem to work, see [here](https://github.com/NumericalMathematics/PositiveIntegrators.jl/actions/runs/22487235876/job/65139846400?pr=168).