### PR TITLE
Fix forcedeps mode with build numbers

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -480,6 +480,19 @@ function get_resolved_versions(manifest_file::String)
 end
 
 """
+    versions_match_ignoring_build(actual, expected)
+
+Return true if two versions are equal, ignoring SemVer build metadata
+(the `+...` suffix). This allows `1.2.3` and `1.2.3+4` to match.
+"""
+function versions_match_ignoring_build(actual::VersionNumber, expected::VersionNumber)
+    return actual.major == expected.major &&
+           actual.minor == expected.minor &&
+           actual.patch == expected.patch &&
+           actual.prerelease == expected.prerelease
+end
+
+"""
     check_forced_lower_bounds(project_file, manifest_file, ignore_pkgs)
 
 Verify that the resolved versions in the manifest match the lower bounds
@@ -503,7 +516,7 @@ function check_forced_lower_bounds(project_file::String, manifest_file::String, 
         # Check if the major.minor.patch matches
         # We compare the full version, but note that the lower bound might be
         # less specific (e.g., "1.2" means v1.2.0)
-        if actual != expected
+        if !versions_match_ignoring_build(actual, expected)
             @error "forcedeps check failed: $pkg resolved to $actual but lower bound is $expected"
             all_match = false
         else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,6 +152,38 @@ downgrade_jl = joinpath(dirname(@__DIR__), "downgrade.jl")
         end
     end
 
+    @testset "forcedeps mode - ignores build metadata" begin
+        mktempdir() do dir
+            cd(dir) do
+                # JLL packages commonly resolve with build metadata (e.g., +0)
+                # while compat lower bounds typically omit it.
+                toml_content = """
+                name = "TestPackage"
+                version = "0.1.0"
+
+                [deps]
+                OpenSSL_jll = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
+
+                [compat]
+                julia = "1.10"
+                OpenSSL_jll = "3.5.0"
+                """
+                write("Project.toml", toml_content)
+
+                # Should pass even when resolved version is like 3.5.0+0
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "forcedeps" "1.10"`)
+
+                manifest = TOML.parsefile("Manifest.toml")
+                deps = manifest["deps"]
+                deps_OpenSSL_jll = get(deps, "OpenSSL_jll", [])
+
+                @test !isempty(deps_OpenSSL_jll)
+                @test startswith(deps_OpenSSL_jll[1]["version"], "3.5.0")
+                @test occursin("+", deps_OpenSSL_jll[1]["version"])
+            end
+        end
+    end
+
     @testset "invalid cases" begin
         # Test invalid mode
         mktempdir() do dir


### PR DESCRIPTION
In https://github.com/DLR-AMR/T8code.jl/pull/109, I noticed a small problem with the forcedeps mode, when JLL packages are involved because they often have build numbers `+x` in their version number. Since the compat bounds in Project.toml do not include the build number, but the resolved version does the exact comparison of the two fails, but we only want to test for major, minor, and patch version. Should be fixed by this PR.
Can you take a quick look please, @ChrisRackauckas?