### PR TITLE
Strip source packages from [targets] during resolution

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -65,11 +65,15 @@ end
     remove_source_packages_from_project(project_file, source_pkgs)
 
 Create a modified version of the Project.toml with source packages
-removed from [deps], [compat], [extras], and [sources] sections.
+removed from [deps], [compat], [extras], [sources], and [targets] sections.
 Returns the original content so it can be restored later.
 
 Note: We must also remove from [sources] because Pkg validates that any
-package in [sources] must be in [deps] or [extras].
+package in [sources] must be in [deps] or [extras]; and from [targets]
+because Pkg validates that any package in a target must be in [deps],
+[weakdeps], or [extras]. A source package that also appears in a test
+target (common in monorepos that dev a sibling package for testing) would
+otherwise leave a dangling target reference once removed from [extras].
 """
 function remove_source_packages_from_project(project_file::String, source_pkgs::Set{String})
     if isempty(source_pkgs)
@@ -89,6 +93,22 @@ function remove_source_packages_from_project(project_file::String, source_pkgs::
             delete!(section, pkg)
             modified = true
             @info "Temporarily removing $pkg from [$section_name] for resolution"
+        end
+    end
+
+    # Remove from each list in [targets]. A source package removed from [extras]
+    # above but left in a target would fail Pkg validation ("Dependency X in
+    # target test not listed in deps, weakdeps or extras") before resolution runs.
+    if haskey(project, "targets")
+        for (target_name, target_list) in project["targets"]
+            target_list isa AbstractVector || continue
+            for pkg in source_pkgs
+                if pkg in target_list
+                    filter!(!isequal(pkg), target_list)
+                    modified = true
+                    @info "Temporarily removing $pkg from [targets.$target_name] for resolution"
+                end
+            end
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -289,6 +289,69 @@ end
         end
     end
 
+    @testset "single project with [sources] path dep used in [targets]" begin
+        # Regression test: a package that devs a sibling via [sources] and also
+        # lists it as a test dependency in [targets]. The source package must be
+        # stripped from [targets] as well as [extras] during resolution, otherwise
+        # Pkg validation fails with "Dependency DevTool in target test not listed
+        # in deps, weakdeps or extras" and the resolver never runs.
+        mktempdir() do dir
+            cd(dir) do
+                # Sibling package that is dev'd via a local path source.
+                mkdir("DevTool")
+                write("DevTool/Project.toml", """
+                name = "DevTool"
+                uuid = "11111111-1111-1111-1111-111111111111"
+                version = "0.1.0"
+                """)
+                mkdir("DevTool/src")
+                write("DevTool/src/DevTool.jl", "module DevTool\nend\n")
+
+                # Package under test: a registry dep plus a path-sourced test dep
+                # that is referenced from [targets].
+                mkdir("SubPackage")
+                write("SubPackage/Project.toml", """
+                name = "SubPackage"
+                uuid = "22222222-2222-2222-2222-222222222222"
+                version = "0.1.0"
+
+                [deps]
+                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                [extras]
+                DevTool = "11111111-1111-1111-1111-111111111111"
+                Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+                [sources]
+                DevTool = {path = "../DevTool"}
+
+                [compat]
+                julia = "1.10"
+                JSON = "0.20, 0.21"
+
+                [targets]
+                test = ["DevTool", "Test"]
+                """)
+
+                # Before the fix this throws a ProcessFailedException.
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "SubPackage" "deps" "1.10"`)
+
+                @test isfile(joinpath("SubPackage", "Manifest.toml"))
+                manifest = TOML.parsefile(joinpath("SubPackage", "Manifest.toml"))
+                deps_JSON = get(manifest["deps"], "JSON", [])
+                @test !isempty(deps_JSON)
+                @test startswith(deps_JSON[1]["version"], "0.20")
+
+                # The original Project.toml must be restored verbatim, including
+                # the [targets] and [sources] entries that were stripped.
+                restored = TOML.parsefile(joinpath("SubPackage", "Project.toml"))
+                @test restored["targets"]["test"] == ["DevTool", "Test"]
+                @test haskey(restored["sources"], "DevTool")
+                @test haskey(restored["extras"], "DevTool")
+            end
+        end
+    end
+
     @testset "merged resolution with test dependencies" begin
         mktempdir() do dir
             cd(dir) do


### PR DESCRIPTION
## Problem

`remove_source_packages_from_project` temporarily removes packages sourced from a local `path` (or `url`) from `[deps]`, `[extras]`, `[compat]`, and `[sources]` so the resolver can run against the registry — but it does **not** remove them from `[targets]`.

When a source package is *also* listed as a test dependency in `[targets]` — which is the normal monorepo layout where a package `dev`s a sibling for its test environment — removing it from `[extras]` leaves a dangling target reference, and Pkg rejects the project before the resolver even starts:

```
ERROR: Dependency `X` in target `test` not listed in `deps`, `weakdeps` or `extras` section
```

This makes the action fail on every such project. It's currently blocking the downgrade CI for the [OrdinaryDiffEq.jl](https://github.com/SciML/OrdinaryDiffEq.jl) monorepo, where each sublibrary `dev`s `DiffEqDevTools`/`DiffEqBase` via `[sources]` and lists them in `[targets].test`.

## Fix

Also strip source packages from every list in `[targets]` while the project is modified for resolution. The original `Project.toml` is restored verbatim afterwards (via `original_content`), so `[targets]` is unchanged from the caller's perspective — this only affects the temporary in-place copy the resolver reads.

## Test

Adds a regression test: a single project that `dev`s a sibling package via `[sources]` and references it from `[targets].test`. Before this change the test's `downgrade.jl` invocation throws `ProcessFailedException`; after it, resolution succeeds and the minimal-version `Manifest.toml` is produced.

Verified locally on Julia 1.11 — the full suite passes (44/44), and a before/after check confirms the unpatched script errors with the message above on this layout while the patched script resolves cleanly.

## Scope / context

This is the first of the issues that block path-dependency monorepos from using `@v2`. A separate, related issue is #3021 (path deps are not re-added to the `Manifest.toml` in the single-directory case, so `buildpkg` fails under `ALLOW_RERESOLVE=false`) — not addressed here to keep this PR focused; happy to follow up with a stacked PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)