### PR TITLE
Re-add local path-sourced packages to the manifest after resolution (#3021)

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -342,6 +342,77 @@ function set_manifest_project_hash(manifest_file::String, project_file::String)
 end
 
 """
+    add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
+
+Re-add local path-sourced packages to `manifest_file` after resolution.
+
+The resolver runs with these packages removed from the project (they cannot be
+resolved from the registry), so they are absent from the resulting manifest even
+though they remain in the project's `[deps]`. Without this, the build step fails
+with errors like "expected package X to be listed in the manifest" / "X is listed
+in Project.toml but absent from Manifest.toml" (see #3021). Each such package is
+written back as a path dependency pointing at the same location given in
+`[sources]`, mirroring `add_main_package_to_manifest`.
+
+Note: only packages that are themselves in `[deps]` need to be in this manifest;
+packages sourced solely for a test target are not part of the resolved
+environment. The path packages' own (unique) transitive dependencies are not
+re-resolved here, so a fully locked test of those is out of scope for this step.
+"""
+function add_source_packages_to_manifest(
+        manifest_file::String, project_file::String, dir::AbstractString, source_pkgs)
+    isempty(source_pkgs) && return
+    if !isfile(manifest_file)
+        @warn "Manifest file not found: $manifest_file"
+        return
+    end
+
+    project = TOML.parsefile(project_file)
+    sources = get(project, "sources", Dict())
+    deps = get(project, "deps", Dict())
+
+    entry_lines = String[]
+    for pkg in source_pkgs
+        # Only packages that are part of this environment's [deps] belong in its
+        # manifest; sources used only by a test target are not.
+        haskey(deps, pkg) || continue
+        src = get(sources, pkg, nothing)
+        (src isa Dict && haskey(src, "path")) || continue
+
+        pkg_path = src["path"]
+        candidates = [joinpath(dir, pkg_path, "Project.toml"),
+                      joinpath(dir, pkg_path, "JuliaProject.toml")]
+        filter!(isfile, candidates)
+        uuid = get(deps, pkg, nothing)
+        version = nothing
+        if !isempty(candidates)
+            pkg_project = TOML.parsefile(first(candidates))
+            uuid = get(pkg_project, "uuid", uuid)
+            version = get(pkg_project, "version", nothing)
+        end
+        if uuid === nothing
+            @warn "Could not determine uuid for source package $pkg, skipping manifest entry"
+            continue
+        end
+
+        push!(entry_lines, "[[deps.$pkg]]")
+        push!(entry_lines, "path = \"$pkg_path\"")
+        push!(entry_lines, "uuid = \"$uuid\"")
+        version !== nothing && push!(entry_lines, "version = \"$version\"")
+        push!(entry_lines, "")
+        @info "Added source package $pkg to manifest as a path dependency"
+    end
+    isempty(entry_lines) && return
+
+    manifest_content = read(manifest_file, String)
+    open(manifest_file, "w") do io
+        print(io, manifest_content)
+        endswith(manifest_content, "\n") || println(io)
+        print(io, join(entry_lines, "\n"))
+    end
+end
+
+"""
     resolve_directory(dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs)
 
 Resolve dependencies for a single directory. Handles source packages by temporarily
@@ -371,6 +442,14 @@ function resolve_directory(
     finally
         # Always restore the original Project.toml, even if resolution fails
         restore_project_file(project_file, original_content)
+    end
+
+    # Re-add local path-sourced packages (removed for resolution) to the manifest
+    # so the resolved environment is complete enough to instantiate/build (#3021),
+    # then refresh the project hash so Pkg sees the manifest as up to date.
+    if !isempty(source_pkgs)
+        add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
+        set_manifest_project_hash(manifest_file, project_file)
     end
 
     # For forcedeps mode, verify that the resolved versions match the lower bounds

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -352,6 +352,68 @@ end
         end
     end
 
+    @testset "single project re-adds [sources] path deps to manifest (#3021)" begin
+        # A path-sourced package listed in [deps] must end up in the resolved
+        # Manifest.toml. It is removed for resolution (can't be resolved from the
+        # registry) and was previously never added back, so the build step failed
+        # with the package present in Project.toml but absent from Manifest.toml.
+        mktempdir() do dir
+            cd(dir) do
+                # Locally-developed dependency referenced by path.
+                mkdir("CorePkg")
+                write("CorePkg/Project.toml", """
+                name = "CorePkg"
+                uuid = "33333333-3333-3333-3333-333333333333"
+                version = "1.2.3"
+                """)
+                mkdir("CorePkg/src")
+                write("CorePkg/src/CorePkg.jl", "module CorePkg\nend\n")
+
+                # Package under test: a registry dep plus a path-sourced dep in [deps].
+                mkdir("SubPackage")
+                write("SubPackage/Project.toml", """
+                name = "SubPackage"
+                uuid = "44444444-4444-4444-4444-444444444444"
+                version = "0.1.0"
+
+                [deps]
+                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                CorePkg = "33333333-3333-3333-3333-333333333333"
+
+                [sources]
+                CorePkg = {path = "../CorePkg"}
+
+                [compat]
+                julia = "1.10"
+                JSON = "0.20, 0.21"
+                """)
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "SubPackage" "deps" "1.10"`)
+
+                manifest_file = joinpath("SubPackage", "Manifest.toml")
+                @test isfile(manifest_file)
+                manifest = TOML.parsefile(manifest_file)
+                deps = manifest["deps"]
+
+                # Registry dep resolved to its minimal version.
+                deps_JSON = get(deps, "JSON", [])
+                @test !isempty(deps_JSON)
+                @test startswith(deps_JSON[1]["version"], "0.20")
+
+                # #3021: the path-sourced dep is present as a path dependency.
+                core_entry = get(deps, "CorePkg", [])
+                @test !isempty(core_entry)
+                @test core_entry[1]["path"] == "../CorePkg"
+                @test core_entry[1]["uuid"] == "33333333-3333-3333-3333-333333333333"
+                @test core_entry[1]["version"] == "1.2.3"
+
+                # Project hash matches what Pkg expects for the restored project.
+                @test manifest["project_hash"] ==
+                      expected_project_hash(joinpath(dir, "SubPackage", "Project.toml"))
+            end
+        end
+    end
+
     @testset "merged resolution with test dependencies" begin
         mktempdir() do dir
             cd(dir) do


### PR DESCRIPTION
Closes #3021.

## Problem

In the single-directory path (`resolve_directory`), packages sourced from a local `path` are removed from the project so the registry resolver can run, the `Project.toml` is restored, but those packages are **never written back into the generated `Manifest.toml`**. The build step then fails because the package is in `Project.toml` but absent from `Manifest.toml`:

```
ERROR: expected package `OrdinaryDiffEqCore [...]` to be registered
```

This is what currently disables `DowngradeSublibraries` CI in OrdinaryDiffEq.jl, where each sublibrary `dev`s sibling packages via `[sources]`.

## Fix

`add_source_packages_to_manifest` writes each removed source package that is part of the project's `[deps]` back into the manifest as a path dependency, using the location from `[sources]` and the `uuid`/`version` from the package's own `Project.toml` — mirroring the existing `add_main_package_to_manifest` used in merge mode. The project hash is then refreshed via `set_manifest_project_hash` so Pkg sees the manifest as up to date.

## Scope (deliberately minimal)

This restores the **path packages themselves**. It does **not** re-resolve their *unique* transitive dependencies — those were stripped along with the path package, so a consumer whose path dep pulls in registry packages not otherwise present in the graph may still need to raise the relevant compat lower bounds. Handling that fully would mean inlining each path dep's `[deps]`/`[compat]` into the resolution; I kept this PR focused on the reported manifest-completeness bug and am happy to follow up with the inlining version if you'd prefer the action to handle it end-to-end.

## Test

Adds a regression test: a single project with a path dep in `[deps]` now produces a `Manifest.toml` that contains that package as a path dependency, with a `project_hash` matching what Pkg expects for the restored project.

Verified locally on Julia 1.11 — full suite passes (46/46), and a manual run confirms the path package is now present in the manifest with the hash refreshed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)