### PR TITLE
Support setup-julia channel aliases (lts, pre, min, nightly) for julia_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ minimal versions and fail if your compat bounds are too low.
 
     # Julia version to use with resolver (requires Julia 1.9+)
     # Default: '1' (converted to current runtime Julia major.minor)
+    # Channel aliases like 'lts', 'pre', 'min', 'nightly', or '1.12-nightly'
+    # are accepted and resolve to the current runtime Julia major.minor,
+    # matching what setup-julia installed for that alias.
     julia_version: '1'
 ```
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,11 @@ minimal versions and fail if your compat bounds are too low.
 
     # Julia version to use with resolver (requires Julia 1.9+)
     # Default: '1' (converted to current runtime Julia major.minor)
-    # Channel aliases like 'lts', 'pre', 'min', 'nightly', or '1.12-nightly'
-    # are accepted and resolve to the current runtime Julia major.minor,
-    # matching what setup-julia installed for that alias.
+    # Channel aliases are also accepted and resolve to the version they
+    # denote: 'lts' / 'release' (from the juliaup version database),
+    # 'pre' (latest version including prereleases), 'min' (the project's
+    # julia compat lower bound), 'nightly' / '1.12-nightly' (current
+    # runtime Julia / the alias's numeric prefix).
     julia_version: '1'
 ```
 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Downgrade mode: deps (direct dependencies), alldeps (deps + weakdeps), weakdeps (only weakdeps), forcedeps (deps with strict lower bound verification)'
     default: 'alldeps'
   julia_version:
-    description: 'Julia version to use with resolver. Channel aliases ("1", "lts", "pre", "min", "nightly", "1.12-nightly", ...) resolve to the current runtime Julia major.minor, matching what setup-julia installed for that alias.'
+    description: 'Julia version to use with resolver. Numeric like "1.10", or a channel alias: "1"/"nightly" (current runtime Julia), "lts"/"release" (juliaup version database), "pre" (latest version incl. prereleases), "min" (the project''s julia compat lower bound).'
     default: '1'
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
     description: 'Downgrade mode: deps (direct dependencies), alldeps (deps + weakdeps), weakdeps (only weakdeps), forcedeps (deps with strict lower bound verification)'
     default: 'alldeps'
   julia_version:
-    description: 'Julia version to use with resolver (default: 1, i.e. current runtime Julia major.minor)'
+    description: 'Julia version to use with resolver. Channel aliases ("1", "lts", "pre", "min", "nightly", "1.12-nightly", ...) resolve to the current runtime Julia major.minor, matching what setup-julia installed for that alias.'
     default: '1'
 runs:
   using: "composite"

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -7,11 +7,21 @@ mode = length(ARGS) >= 3 ? ARGS[3] : "deps"
 current_julia_minor = string(VERSION.major, ".", VERSION.minor)
 julia_version = length(ARGS) >= 4 ? ARGS[4] : current_julia_minor
 
-# Convert "1" to the current running Julia version (e.g., "1.12" for Julia 1.12.3)
-# This ensures the resolved manifest matches the Julia version that will read it
-if julia_version == "1"
+# Convert "1" and channel aliases ("lts", "pre", "min", "nightly", ...) to the
+# current running Julia version (e.g., "1.12" for Julia 1.12.3). The resolver
+# only accepts numeric compat specs, but in CI an alias has already been
+# resolved by setup-julia to the Julia this script runs under, so the runtime
+# version is exactly what the alias refers to. This also ensures the resolved
+# manifest matches the Julia version that will read it.
+if julia_version == "1" || occursin(r"^[A-Za-z]", julia_version)
+    original_spec = julia_version
     julia_version = current_julia_minor
-    @info "Converted julia_version \"1\" to \"$julia_version\" (current Julia version)"
+    @info "Converted julia_version \"$original_spec\" to \"$julia_version\" (current Julia version)"
+elseif (m = match(r"^(\d+\.\d+)-[A-Za-z]", julia_version)) !== nothing
+    # Versioned channel aliases like "1.12-nightly": keep the numeric part
+    original_spec = julia_version
+    julia_version = m.captures[1]
+    @info "Converted julia_version \"$original_spec\" to \"$julia_version\" (numeric prefix of channel alias)"
 end
 
 if julia_version != current_julia_minor

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -1,5 +1,6 @@
 using TOML
 using Pkg
+using Downloads
 
 ignore_pkgs = filter(!isempty, map(strip, split(ARGS[1], ",")))
 dirs = filter(!isempty, map(strip, split(ARGS[2], ",")))
@@ -7,21 +8,79 @@ mode = length(ARGS) >= 3 ? ARGS[3] : "deps"
 current_julia_minor = string(VERSION.major, ".", VERSION.minor)
 julia_version = length(ARGS) >= 4 ? ARGS[4] : current_julia_minor
 
-# Convert "1" and channel aliases ("lts", "pre", "min", "nightly", ...) to the
-# current running Julia version (e.g., "1.12" for Julia 1.12.3). The resolver
-# only accepts numeric compat specs, but in CI an alias has already been
-# resolved by setup-julia to the Julia this script runs under, so the runtime
-# version is exactly what the alias refers to. This also ensures the resolved
-# manifest matches the Julia version that will read it.
-if julia_version == "1" || occursin(r"^[A-Za-z]", julia_version)
+# The resolver only accepts numeric compat specs, so setup-julia channel
+# aliases ("lts", "pre", "min", "nightly", ...) must be converted to a numeric
+# major.minor first. Each alias is resolved to what it actually denotes (the
+# same thing setup-julia would install for it), not to the runtime Julia:
+#   - "lts"/"release": the juliaup version database's channel mapping
+#   - "pre": the highest version (prereleases included) in the official
+#     versions.json, matching setup-julia's includePrerelease resolution
+#   - "min": the lower bound of the project's own `julia` compat entry
+#   - "nightly"/"X.Y-nightly": nightlies have no registry presence, so use the
+#     runtime Julia / the numeric prefix (under setup-julia these match)
+# The versiondb/versions.json are machine-generated with a stable shape, so the
+# needed fields are extracted with targeted regexes rather than a JSON parser
+# (none is available in stdlib for the Julia versions this action supports).
+
+"""
+    compat_lower_bound_minor(compat_str)
+
+Lower bound of a Pkg compat entry as "major.minor", e.g. "1.6, 1.10" -> "1.6",
+"^1.10" -> "1.10", "1.6 - 1.12" -> "1.6".
+"""
+function compat_lower_bound_minor(compat_str::AbstractString)
+    first_spec = strip(first(split(compat_str, ",")))
+    m = match(r"(\d+)(?:\.(\d+))?", first_spec)
+    m === nothing && error("Cannot parse julia compat entry: $compat_str")
+    return string(m.captures[1], ".", something(m.captures[2], "0"))
+end
+
+function resolve_julia_version_spec(spec::AbstractString, dirs, current_julia_minor)
+    spec == "1" && return current_julia_minor
+    if spec in ("lts", "release")
+        url = "https://raw.githubusercontent.com/JuliaLang/juliaup/main/versiondb/versiondb-x86_64-unknown-linux-gnu.json"
+        db = read(Downloads.download(url), String)
+        m = match(Regex("\"$spec\"\\s*:\\s*\\{\\s*\"Version\"\\s*:\\s*\"(\\d+\\.\\d+)"), db)
+        m === nothing && error("Could not find the \"$spec\" channel in the juliaup version database")
+        return String(m.captures[1])
+    end
+    if spec == "pre"
+        vj = read(Downloads.download("https://julialang-s3.julialang.org/bin/versions.json"), String)
+        vers = [VersionNumber(m.captures[1])
+                for m in eachmatch(r"\"(\d+\.\d+\.\d+(?:-[A-Za-z0-9.]+)?)\"\s*:\s*\{", vj)]
+        isempty(vers) && error("Could not parse any versions from versions.json")
+        v = maximum(vers)
+        return string(v.major, ".", v.minor)
+    end
+    if spec == "min"
+        isempty(dirs) && error("julia_version \"min\" requires at least one project")
+        project_file = joinpath(dirs[1], "Project.toml")
+        isfile(project_file) || (project_file = joinpath(dirs[1], "JuliaProject.toml"))
+        isfile(project_file) || error("julia_version \"min\": no Project.toml in $(dirs[1])")
+        compat = get(get(TOML.parsefile(project_file), "compat", Dict()), "julia", nothing)
+        compat === nothing &&
+            error("julia_version \"min\": no `julia` compat entry in $project_file")
+        return compat_lower_bound_minor(compat)
+    end
+    spec == "nightly" && return current_julia_minor
+    m = match(r"^(\d+\.\d+)-[A-Za-z]", spec)
+    m !== nothing && return String(m.captures[1])
+    # Reject unknown aliases with a clear message instead of the resolver's
+    # cryptic "Invalid compat version spec"; anything else (numeric versions
+    # and other resolver-understood specs) passes through unchanged.
+    occursin(r"^[A-Za-z]+$", spec) &&
+        error("Unsupported julia_version channel alias \"$spec\". Use a numeric " *
+              "version like \"1.10\" or one of: 1, lts, release, pre, min, " *
+              "nightly, <major.minor>-nightly.")
+    return spec
+end
+
+if julia_version != current_julia_minor
     original_spec = julia_version
-    julia_version = current_julia_minor
-    @info "Converted julia_version \"$original_spec\" to \"$julia_version\" (current Julia version)"
-elseif (m = match(r"^(\d+\.\d+)-[A-Za-z]", julia_version)) !== nothing
-    # Versioned channel aliases like "1.12-nightly": keep the numeric part
-    original_spec = julia_version
-    julia_version = m.captures[1]
-    @info "Converted julia_version \"$original_spec\" to \"$julia_version\" (numeric prefix of channel alias)"
+    julia_version = resolve_julia_version_spec(julia_version, dirs, current_julia_minor)
+    if julia_version != original_spec
+        @info "Converted julia_version \"$original_spec\" to \"$julia_version\""
+    end
 end
 
 if julia_version != current_julia_minor

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,6 +59,47 @@ end
         end
     end
 
+    # Channel aliases are resolved by setup-julia before the action runs, so the
+    # script maps them to the current runtime Julia major.minor instead of
+    # passing them to the resolver (which only accepts numeric compat specs).
+    @testset "channel alias julia_version specs" begin
+        current_minor = string(VERSION.major, ".", VERSION.minor)
+        for spec in ["lts", "pre", "min", "nightly", "$(current_minor)-nightly"]
+            @testset "julia_version = $spec" begin
+                mktempdir() do dir
+                    cd(dir) do
+                        toml_content = """
+                        name = "TestPackage"
+                        version = "0.1.0"
+
+                        [deps]
+                        JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                        DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                        [compat]
+                        julia = "1.10"
+                        JSON = "0.20, 0.21"
+                        DataStructures = "0.17, 0.18"
+                        """
+                        write("Project.toml", toml_content)
+
+                        run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" $spec`)
+
+                        @test isfile("Manifest.toml")
+                        manifest = TOML.parsefile("Manifest.toml")
+                        deps = manifest["deps"]
+                        deps_JSON = get(deps, "JSON", [])
+                        deps_DataStructures = get(deps, "DataStructures", [])
+                        @test !isempty(deps_JSON)
+                        @test !isempty(deps_DataStructures)
+                        @test startswith(deps_JSON[1]["version"], "0.20")
+                        @test startswith(deps_DataStructures[1]["version"], "0.17")
+                    end
+                end
+            end
+        end
+    end
+
     @testset "forcedeps mode - passes when lower bounds match" begin
         mktempdir() do dir
             cd(dir) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,42 +59,99 @@ end
         end
     end
 
-    # Channel aliases are resolved by setup-julia before the action runs, so the
-    # script maps them to the current runtime Julia major.minor instead of
-    # passing them to the resolver (which only accepts numeric compat specs).
+    # The resolver only accepts numeric compat specs, so setup-julia channel
+    # aliases must be converted to the numeric version they actually denote
+    # (lts/release/pre from the official version databases, min from the
+    # project's julia compat lower bound, nightly from the runtime).
     @testset "channel alias julia_version specs" begin
         current_minor = string(VERSION.major, ".", VERSION.minor)
-        for spec in ["lts", "pre", "min", "nightly", "$(current_minor)-nightly"]
-            @testset "julia_version = $spec" begin
-                mktempdir() do dir
-                    cd(dir) do
-                        toml_content = """
+
+        # Run the script with the given spec in a fresh project; return the
+        # numeric version the alias was converted to, whether the full
+        # resolution succeeded, and the parsed manifest (or nothing).
+        function run_with_spec(spec)
+            mktempdir() do dir
+                cd(dir) do
+                    write(
+                        "Project.toml",
+                        """
                         name = "TestPackage"
                         version = "0.1.0"
 
                         [deps]
                         JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-                        DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 
                         [compat]
                         julia = "1.10"
                         JSON = "0.20, 0.21"
-                        DataStructures = "0.17, 0.18"
+                        """,
+                    )
+                    err = IOBuffer()
+                    proc = run(pipeline(
+                            `$(Base.julia_cmd()) $downgrade_jl "" "." "deps" $spec`;
+                            stderr = err,
+                        ); wait = false)
+                    wait(proc)
+                    log = String(take!(err))
+                    m = match(r"Converted julia_version \"[^\"]+\" to \"(\d+\.\d+)\"", log)
+                    converted = m === nothing ? nothing : String(m.captures[1])
+                    manifest = isfile("Manifest.toml") ? TOML.parsefile("Manifest.toml") :
+                        nothing
+                    success(proc) || println("[$spec] script failed; log:\n", log)
+                    return converted, success(proc), manifest
+                end
+            end
+        end
+
+        # Deterministic aliases: target <= runtime, so resolution must succeed
+        min_v, min_ok, min_manifest = run_with_spec("min")
+        @test min_v == "1.10"  # the project's julia compat lower bound
+        @test min_ok
+        @test startswith(min_manifest["deps"]["JSON"][1]["version"], "0.20")
+
+        nightly_v, nightly_ok, _ = run_with_spec("nightly")
+        @test nightly_v == current_minor
+        @test nightly_ok
+
+        versioned_nightly_v, versioned_nightly_ok, _ = run_with_spec("$(current_minor)-nightly")
+        @test versioned_nightly_v == current_minor
+        @test versioned_nightly_ok
+
+        # Database-resolved aliases: exact values change over time, so check
+        # they are numeric and correctly ordered (lts <= release <= pre). The
+        # lts target is never newer than a supported runtime, so its full
+        # resolution must succeed; release/pre may target a Julia newer than
+        # the runtime, where the resolver legitimately lacks stdlib data
+        # (cross-runtime mode), so only the conversion is asserted for them.
+        lts_v, lts_ok, lts_manifest = run_with_spec("lts")
+        release_v, _, _ = run_with_spec("release")
+        pre_v, _, _ = run_with_spec("pre")
+        @test lts_v !== nothing && release_v !== nothing && pre_v !== nothing
+        @test VersionNumber(lts_v) >= v"1.6"
+        @test VersionNumber(lts_v) <= VersionNumber(release_v)
+        @test VersionNumber(release_v) <= VersionNumber(pre_v)
+        @test lts_ok
+        @test startswith(lts_manifest["deps"]["JSON"][1]["version"], "0.20")
+
+        # Unknown aliases fail with a clear error instead of reaching the resolver
+        @testset "unknown alias rejected" begin
+            mktempdir() do dir
+                cd(dir) do
+                    write(
+                        "Project.toml",
                         """
-                        write("Project.toml", toml_content)
-
-                        run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" $spec`)
-
-                        @test isfile("Manifest.toml")
-                        manifest = TOML.parsefile("Manifest.toml")
-                        deps = manifest["deps"]
-                        deps_JSON = get(deps, "JSON", [])
-                        deps_DataStructures = get(deps, "DataStructures", [])
-                        @test !isempty(deps_JSON)
-                        @test !isempty(deps_DataStructures)
-                        @test startswith(deps_JSON[1]["version"], "0.20")
-                        @test startswith(deps_DataStructures[1]["version"], "0.17")
-                    end
+                        name = "TestPackage"
+                        version = "0.1.0"
+                        """,
+                    )
+                    err = IOBuffer()
+                    proc = run(pipeline(
+                            `$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "notachannel"`;
+                            stderr = err,
+                        ); wait = false)
+                    wait(proc)
+                    @test !success(proc)
+                    @test occursin("Unsupported julia_version channel alias", String(take!(err)))
                 end
             end
         end


### PR DESCRIPTION
**Please ignore until reviewed by @ChrisRackauckas.**

## Problem

`julia_version` is passed straight through to Resolver.jl's `resolve.jl`, which only accepts numeric compat specs. Passing a setup-julia channel alias fails:

```
[ERROR] Invalid compat version spec: --julia=lts
```

This bit SciML's reusable sublibrary downgrade workflow (SciML/.github#83, broke `Downgrade Sublibraries` on SciML/LinearSolve.jl `main`), and affects any consumer whose workflow matrix uses `lts`/`pre`/`min`/`nightly` for both `setup-julia` and this action.

## Fix

Aliases are converted to the numeric `major.minor` they actually denote (matching what setup-julia would install for them), **not** the runtime Julia:

| spec | resolves to | source |
|---|---|---|
| `lts` / `release` | e.g. `1.10` / `1.12` today | juliaup version database channel mapping |
| `pre` | e.g. `1.13` today | highest version incl. prereleases in the official versions.json |
| `min` | the project's `julia` compat lower bound | local Project.toml |
| `1` / `nightly` / `X.Y-nightly` | runtime major.minor / numeric prefix | nightlies have no registry presence; `1` keeps its existing behavior |
| unknown alias | clear error listing supported specs | (replaces the cryptic resolver error) |

Numeric specs pass through unchanged, and the existing cross-runtime warning still fires when the resolved target differs from the runtime (e.g. `lts` on a `1.12` runner).

The versiondb/versions.json are machine-generated with a stable shape, so the needed fields are extracted with targeted regexes (no JSON parser exists in stdlib for the Julia versions this action supports).

```
[ Info: Converted julia_version "lts" to "1.10"
[ Info: Converted julia_version "pre" to "1.13"
[ Info: Converted julia_version "min" to "1.10"
```

Known limitation (pre-existing, now just reachable via aliases): when the resolved target is **newer** than the runtime (e.g. `pre` on a stable runner), Resolver.jl lacks stdlib data for the unreleased Julia and resolution fails — the README's documented cross-runtime caveat. Targets ≤ runtime (the downgrade use case) work.

## Testing

- New testset asserts exact conversions for the deterministic aliases (`min` → the project's compat lower bound, `nightly`/`X.Y-nightly` → runtime) including full resolution to minimal versions, ordering `lts ≤ release ≤ pre` for the database-resolved ones (full resolution asserted for `lts`), and that unknown aliases fail with the clear error.
- Full local suite on Julia 1.12.4: **79/79 pass** (`julia test/runtests.jl`, 6m39s).

Also updated the `action.yml` input description and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)