### PR TITLE
Dedupe main package in manifest after merged resolution (fix "ambiguous" manifest error)

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -357,12 +357,47 @@ function should_merge_projects(dirs)
 end
 
 """
+    remove_manifest_entries_by_uuid!(manifest, uuid)
+
+Remove from a parsed manifest any package stanza whose `uuid` equals `uuid`,
+returning the names of the packages that were removed. Handles both manifest
+formats: Julia ≥1.7 manifests nest the package tables under a top-level `deps`
+table, while older (≤1.6) manifests place them directly at the top level. Only
+entries matching `uuid` are touched; everything else is left intact.
+"""
+function remove_manifest_entries_by_uuid!(manifest::AbstractDict, uuid::AbstractString)
+    # In ≥1.7 manifests the per-package arrays live under `deps`; in ≤1.6 they
+    # live at the top level alongside metadata keys like `julia_version`.
+    deps = get(manifest, "deps", manifest)
+    removed = String[]
+    for (name, entries) in collect(deps)
+        # Skip metadata scalars present in old-style top-level manifests.
+        entries isa AbstractVector || continue
+        if any(e -> e isa AbstractDict && get(e, "uuid", nothing) == uuid, entries)
+            delete!(deps, name)
+            push!(removed, name)
+        end
+    end
+    return removed
+end
+
+"""
     add_main_package_to_manifest(manifest_file, main_project_file)
 
 Add the main package itself to the manifest as a path dependency.
 This is needed because the main package is excluded from resolution
 (it's a local source), but the manifest needs to include it for
 workspace projects to work correctly.
+
+If the resolver already emitted a registry entry for the main package, that
+entry is removed first. This happens in the merged-resolution path whenever a
+test extra transitively depends on the main package (e.g. LinearSolve's test
+extra AlgebraicMultigrid depends on LinearSolve): the merged resolve installs
+the main package from the registry, so blindly appending the path stanza would
+leave two `[[deps.<MainPkg>]]` entries with the same name and uuid. Pkg then
+rejects the manifest with "Invalid manifest format: ...'s dependency on
+<MainPkg> is ambiguous". The path entry must win, since the main package is
+sourced locally, not from the registry.
 """
 function add_main_package_to_manifest(manifest_file::String, main_project_file::String; path::String = ".")
     if !isfile(manifest_file)
@@ -380,6 +415,18 @@ function add_main_package_to_manifest(manifest_file::String, main_project_file::
     if pkg_name === nothing || pkg_uuid === nothing
         @warn "Main project missing name or uuid, cannot add to manifest"
         return
+    end
+
+    # Drop any resolver-emitted entry for the main package (matched by uuid, so
+    # a renamed-but-same-package stanza is still caught) before appending the
+    # path stanza; a duplicate would make the manifest invalid.
+    manifest = TOML.parsefile(manifest_file)
+    removed = remove_manifest_entries_by_uuid!(manifest, pkg_uuid)
+    if !isempty(removed)
+        open(manifest_file, "w") do io
+            TOML.print(io, manifest; sorted = true)
+        end
+        @info "Removed resolver-emitted registry entry for main package $pkg_name"
     end
 
     # Read the manifest content as text to preserve formatting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -816,4 +816,70 @@ end
             end
         end
     end
+
+    @testset "merged resolution: test extra depending on the main package" begin
+        # Regression for the duplicate main-package manifest entry. When a
+        # project uses [extras]+[targets].test and a test extra transitively
+        # depends on the main package, the merged resolve installs the main
+        # package FROM THE REGISTRY too. add_main_package_to_manifest then has
+        # to replace that registry stanza with the path stanza; blindly
+        # appending it leaves two [[deps.<MainPkg>]] entries with the same uuid,
+        # and Pkg rejects the manifest with "Invalid manifest format: ...'s
+        # dependency on <MainPkg> is ambiguous" (exit 1) at set_manifest_project_hash.
+        #
+        # Mirrors SciML/LinearSolve.jl, whose test extra AlgebraicMultigrid
+        # depends on LinearSolve. Here the registered pair
+        # DataStructures -> OrderedCollections plays the same roles, with the
+        # local package masquerading as the registered OrderedCollections so the
+        # resolver emits a registry entry under the main package's uuid. The
+        # current runtime julia_version ("1") is used because the resolver
+        # currently fails cross-runtime resolution for [sources]/path projects.
+        mktempdir() do dir
+            cd(dir) do
+                toml_content = """
+                name = "OrderedCollections"
+                uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+                version = "1.6.0"
+
+                [deps]
+
+                [extras]
+                DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                [compat]
+                julia = "1.10"
+                DataStructures = "0.18"
+
+                [targets]
+                test = ["DataStructures"]
+                """
+                write("Project.toml", toml_content)
+                mkdir("src")
+                write("src/OrderedCollections.jl", "module OrderedCollections\nend\n")
+
+                # Before the fix this exits 1 with the "ambiguous" manifest error.
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1"`)
+
+                @test isfile("Manifest.toml")
+
+                # (a) The manifest must re-parse via Pkg (it rejects duplicate
+                # name/uuid stanzas with the ambiguity error).
+                Pkg.Types.EnvCache("Project.toml")
+
+                manifest = TOML.parsefile("Manifest.toml")
+                deps = manifest["deps"]
+
+                # The test extra and its transitive dep are present.
+                @test haskey(deps, "DataStructures")
+
+                # (b) Exactly one stanza for the main package, and it is the path
+                # entry pointing at the project dir, not the registry stanza.
+                main_entries = get(deps, "OrderedCollections", [])
+                @test length(main_entries) == 1
+                @test main_entries[1]["path"] == "."
+                @test main_entries[1]["uuid"] == "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+                @test main_entries[1]["version"] == "1.6.0"
+            end
+        end
+    end
 end


### PR DESCRIPTION
## The bug

Since #49 (merged 2026-06-11), the action errors out for any project that uses old-style test dependencies (`[extras]` + `[targets].test`) where a test extra transitively depends on the main package. The action fails on the unmodified base branch with:

```
ERROR: LoadError: Invalid manifest format. `AlgebraicMultigrid=2169fc97-...`'s dependency on `LinearSolve` is ambiguous.
```

and exits 1.

This is hitting SciML downgrade CI. Concrete reproduction: **SciML/LinearSolve.jl**, whose test extra `AlgebraicMultigrid` depends on `LinearSolve` — see the failing `Downgrade / Downgrade Tests - Core` job in run [27492921665 / job 81261444725](https://github.com/SciML/LinearSolve.jl/actions/runs/27492921665/job/81261444725). The last green runs were before the floating `@v2` tag advanced to include #49.

## Root cause

#49 added a *merged-resolution* path: for projects with `[extras]` + `[targets].test`, the main project and its extras are resolved together (`create_merged_project` → resolver). When a test extra transitively depends on the main package, that merged resolve **also installs the main package from the registry**, so the resolved `Manifest.toml` already contains a `[[deps.<MainPkg>]]` stanza.

`add_main_package_to_manifest` then **blindly appends** a second, path-based `[[deps.<MainPkg>]]` stanza:

```julia
# Append the main package entry to the manifest
open(manifest_file, "w") do io
    print(io, manifest_content)
    ...
    print(io, main_pkg_entry)   # <-- second stanza, same name + uuid
end
```

Now the manifest has **two stanzas for the main package with the same name and UUID**. The next step, `set_manifest_project_hash`, re-parses the manifest via `Pkg.Types.EnvCache`, which can't disambiguate the dependent extra's reference to the main package → the "ambiguous" error above → exit 1.

(`add_source_packages_to_manifest` already guards against exactly this for `[sources]` path packages — it drops the resolver-emitted registry entry before appending the path entry. `add_main_package_to_manifest` was missing the equivalent guard.)

## The fix

Before appending the path stanza, scan the resolved manifest for any stanza whose `uuid` equals the main package's UUID and remove it, so **exactly one** stanza (the path one) remains. Matching by UUID — rather than name — mirrors the existing `[sources]` dedupe and is robust to a renamed-but-same-package stanza. A small helper `remove_manifest_entries_by_uuid!` handles both manifest formats (Julia ≥1.7 nested under `[deps]`; ≤1.6 at the top level) and only touches entries matching the main package's UUID, leaving everything else intact. The path entry wins, which is correct: the main package is sourced locally, not from the registry.

## Regression test

Added a testset that drives the **full merged-resolution path** end to end with a test extra that depends on the main package. Since the real LinearSolve←AlgebraicMultigrid pair can't be reproduced with an unregistered local package, it uses the registered pair `DataStructures` → `OrderedCollections` (DataStructures depends on OrderedCollections) playing the same roles: the local package masquerades as the registered `OrderedCollections`, so the merged resolve emits a registry stanza under the main package's UUID, triggering the dedupe path. The test asserts the action no longer errors, the manifest re-parses via `Pkg.Types.EnvCache`, and the main package has exactly one stanza — the path one.

Verification (Julia 1.11.9, locally):
- Reproduced the original failure on the **unfixed** code: the new test errors with `Invalid manifest format. DataStructures=...'s dependency on OrderedCollections is ambiguous`, exit 1.
- With the fix, the new test passes and the log shows `Removed resolver-emitted registry entry for main package OrderedCollections` (confirming the merged resolve did install it from the registry).
- Full suite green: `julia-downgrade-compat resolver tests | 93 93 Pass` (0 fail, 0 error).