### PR TITLE
Strip [sources] packages from merged project before resolution

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -234,6 +234,24 @@ function create_merged_project(main_project_file::String, test_project_file::Str
     # Remove workspace section (not needed for resolution)
     delete!(merged, "workspace")
 
+    # Strip in-tree [sources] path/url packages from the merged project. They are
+    # not registered, so if they remain in [deps]/[compat]/[sources] the resolver
+    # errors "unknown package UUID: ..." (e.g. a monorepo root whose [deps] are its
+    # own unregistered lib/* sources). The merge logic below already skips ADDING
+    # source packages from extras/test-deps, but a source package listed directly
+    # in the main project's [deps] (a monorepo root depending on its siblings)
+    # would otherwise survive the deepcopy. This mirrors the non-merged path's
+    # remove_source_packages_from_project. They are re-added to the manifest as
+    # path deps after resolution (add_source_packages_to_manifest).
+    for section_name in ("deps", "compat", "sources")
+        if haskey(merged, section_name)
+            for pkg in source_pkgs
+                delete!(merged[section_name], pkg)
+            end
+            isempty(merged[section_name]) && delete!(merged, section_name)
+        end
+    end
+
     # Merge extras from main project into deps (old-style test dependencies)
     # This ensures that even in the "new style" with test/Project.toml, any
     # legacy extras in the root project that might still be used are included.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -882,4 +882,93 @@ end
             end
         end
     end
+
+    @testset "merged resolution: source sibling in main [deps] (monorepo root)" begin
+        # Regression for SciML/OptimalUncertaintyQuantification.jl Downgrade Core /
+        # Downgrade Sublibraries. A monorepo ROOT (or a sublibrary) lists an
+        # unregistered in-repo sibling directly in its main [deps] and pins it via
+        # [sources], AND uses [extras]+[targets].test (merged resolution path).
+        # create_merged_project starts from deepcopy(main_project), which retains
+        # the sibling in [deps]/[compat]/[sources]; the resolver then errors
+        # "unknown package UUID: <sibling>" before resolving anything. The merged
+        # project must strip source packages from [deps]/[compat]/[sources], the
+        # same way the non-merged path does.
+        mktempdir() do dir
+            cd(dir) do
+                # Unregistered in-repo sibling with a made-up uuid.
+                mkpath("lib/MySib/src")
+                write(
+                    "lib/MySib/Project.toml",
+                    """
+                    name = "MySib"
+                    uuid = "11111111-2222-3333-4444-555555555555"
+                    version = "0.1.0"
+                    """
+                )
+                write("lib/MySib/src/MySib.jl", "module MySib\nend\n")
+
+                # Root package depends on the sibling (in [deps], pinned via
+                # [sources]) plus a real registry dep, and declares old-style test
+                # deps via [extras]/[targets].test to force the merged path.
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "598b003f-0677-49cf-8d2a-39b1658b755a"
+                    version = "0.1.0"
+
+                    [deps]
+                    MySib = "11111111-2222-3333-4444-555555555555"
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [extras]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [compat]
+                    julia = "1.10"
+                    MySib = "0.1"
+                    JSON = "0.20, 0.21"
+                    DataStructures = "0.17, 0.18"
+
+                    [sources]
+                    MySib = { path = "lib/MySib" }
+
+                    [targets]
+                    test = ["DataStructures"]
+                    """
+                )
+                mkdir("src")
+                write("src/RootPkg.jl", "module RootPkg\nusing MySib\nend\n")
+
+                # Before the fix this exits 1 with
+                # "unknown package UUID: 11111111-...". MySib is in the skip list
+                # (the workflow skips [sources] names), but that only prevents
+                # compat-rewriting -- the resolver still chokes on it in [deps].
+                run(`$(Base.julia_cmd()) $downgrade_jl "MySib" "." "deps" "1.10"`)
+
+                @test isfile("Manifest.toml")
+                # Manifest must re-parse via Pkg.
+                Pkg.Types.EnvCache("Project.toml")
+
+                manifest = TOML.parsefile("Manifest.toml")
+                deps = manifest["deps"]
+
+                # Registry dep was minimized.
+                deps_JSON = get(deps, "JSON", [])
+                @test !isempty(deps_JSON)
+                @test startswith(deps_JSON[1]["version"], "0.20")
+
+                # The source sibling is re-added to the manifest as a path dep.
+                deps_MySib = get(deps, "MySib", [])
+                @test !isempty(deps_MySib)
+                @test deps_MySib[1]["path"] == joinpath("lib", "MySib")
+                @test deps_MySib[1]["uuid"] == "11111111-2222-3333-4444-555555555555"
+
+                # The original Project.toml is restored (still lists the source).
+                restored = TOML.parsefile("Project.toml")
+                @test haskey(restored["deps"], "MySib")
+                @test haskey(restored, "sources") && haskey(restored["sources"], "MySib")
+            end
+        end
+    end
 end


### PR DESCRIPTION
**Ignore until reviewed by @ChrisRackauckas.**

## Problem

`create_merged_project` (the `[extras]`+`[targets].test` "merged resolution" path) starts from `deepcopy(main_project)`. It already avoids *adding* source packages from extras/test-deps, but a source package listed directly in the main project's `[deps]` — a monorepo **root** (or sublibrary) that depends on its own unregistered in-repo siblings and pins them via `[sources]` — survives the deepcopy in `[deps]`/`[compat]`/`[sources]`. Resolver.jl then errors before resolving anything:

```
ERROR: LoadError: unknown package UUID: 01930cae-99d2-7439-8f4f-ace2ece9f1b9
  @ Resolver .../src/PkgInfo.jl:23
[ Info: Running resolver on merged project (extras) for . with --min=@deps
```

The caller-supplied skip list (the SciML downgrade workflow skips every `[sources]` name) does **not** help: it only stops `julia-downgrade-compat` from rewriting their `[compat]` to `=<floor>`; the resolver still receives them as deps of the merged project.

## Reproduction

SciML/OptimalUncertaintyQuantification.jl (a `lib/` monorepo whose root and each sublibrary pin in-repo siblings via `[sources]`):

- **Downgrade Core**: root `[deps]` = `CanonicalMoments`, `OUQBase`, `DiscreteMeasures` → `unknown package UUID: 01930cae-...` (OUQBase).
- **Downgrade Sublibraries / lib/CanonicalMoments**: `[deps] DiscreteMeasures` → `unknown package UUID: 7766d772-...`.

Both fail in the merged path; the non-merged path already handles this via `remove_source_packages_from_project`.

## Fix

Strip source packages from the merged project's `[deps]`/`[compat]`/`[sources]` (mirroring `remove_source_packages_from_project`). They are re-added to the manifest as path deps after resolution by `add_source_packages_to_manifest`, so the resolved environment stays complete.

## Verification (run locally, Julia 1.10)

- Full test suite **101/101** (adds a regression test: monorepo root with a source sibling in main `[deps]` plus `[extras]`/`[targets].test`).
- Against the failing repo: with this `downgrade.jl`, both the root (`Successfully resolved minimal versions for .`) and `lib/CanonicalMoments` (`Successfully resolved minimal versions for lib/CanonicalMoments`) resolve, where the released action errored `unknown package UUID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)