### PR TITLE
Add `no_promote`: exclude a currently-unresolvable backend (Mooncake) from the merged promotion

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,13 @@ inputs:
   julia_version:
     description: 'Julia version to use with resolver. Numeric like "1.10", or a channel alias: "1"/"nightly" (current runtime Julia), "lts"/"release" (juliaup version database), "pre" (latest version incl. prereleases), "min" (the project''s julia compat lower bound).'
     default: '1'
+  no_promote:
+    description: 'Comma-separated weakdep extensions to keep as weakdeps in the merged resolution instead of promoting them into the joint floor-resolve. Every other weakdep extension is still promoted and floor-tested together; use this only to exclude a backend that is currently unresolvable on its own (e.g. "Mooncake", whose graph Resolver.jl cannot --min-resolve).'
+    default: ''
 runs:
   using: "composite"
   steps:
-    - run: julia --color=yes "${{ github.action_path }}/downgrade.jl" "${{ inputs.skip }}" "${{ inputs.projects }}" "${{ inputs.mode }}" "${{ inputs.julia_version }}"
+    - run: julia --color=yes "${{ github.action_path }}/downgrade.jl" "${{ inputs.skip }}" "${{ inputs.projects }}" "${{ inputs.mode }}" "${{ inputs.julia_version }}" "${{ inputs.no_promote }}"
       shell: bash
 branding:
   icon: trending-down

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -7,6 +7,15 @@ dirs = filter(!isempty, map(strip, split(ARGS[2], ",")))
 mode = length(ARGS) >= 3 ? ARGS[3] : "deps"
 current_julia_minor = string(VERSION.major, ".", VERSION.minor)
 julia_version = length(ARGS) >= 4 ? ARGS[4] : current_julia_minor
+# Weakdep extensions to keep as weakdeps in the merged project instead of
+# promoting them to hard [deps]. The merged resolution otherwise force-min-
+# resolves every promoted weakdep together (the extensions all coexist in one
+# test env, so testing them together is correct); use this only to exclude a
+# backend that is currently unresolvable on its own -- e.g. Mooncake, whose graph
+# Resolver.jl cannot --min-resolve (StefanKarpinski/Resolver.jl#24). The excluded
+# backend stays a weakdep (installed at latest), every other extension is still
+# floor-tested jointly.
+no_promote = length(ARGS) >= 5 ? filter(!isempty, map(strip, split(ARGS[5], ","))) : String[]
 
 # The resolver only accepts numeric compat specs, so setup-julia channel
 # aliases ("lts", "pre", "min", "nightly", ...) must be converted to a numeric
@@ -218,7 +227,8 @@ both environments), the resolved versions are compatible.
 
 Returns a Set of source packages that were excluded from the merge.
 """
-function create_merged_project(main_project_file::String, test_project_file::String, merged_dir::String)
+function create_merged_project(main_project_file::String, test_project_file::String, merged_dir::String;
+        no_promote = String[])
     main_project = TOML.parsefile(main_project_file)
     test_project = TOML.parsefile(test_project_file)
 
@@ -257,10 +267,21 @@ function create_merged_project(main_project_file::String, test_project_file::Str
     # legacy extras in the root project that might still be used are included.
     # For the "old style" case where test_project_file == main_project_file,
     # this is where the test dependencies are actually added to [deps].
+    main_weakdeps = get(main_project, "weakdeps", Dict())
     if haskey(main_project, "extras")
         deps = get!(merged, "deps", Dict{String, Any}())
         for (pkg, uuid) in main_project["extras"]
             if pkg ∉ source_pkgs
+                # A weakdep extension named in `no_promote` is left as a weakdep
+                # (installed at latest, never force-min-resolved), instead of being
+                # promoted into the joint floor-resolve. Used to exclude a backend
+                # that is currently unresolvable on its own (e.g. Mooncake); every
+                # other extension is still promoted and floor-tested together.
+                if pkg in no_promote && haskey(main_weakdeps, pkg)
+                    @info "Keeping $pkg as a weakdep in merged project (listed in no_promote)"
+                    continue
+                end
+
                 if !haskey(deps, pkg)
                     deps[pkg] = uuid
                     @info "Adding main project extra to merged project: $pkg"
@@ -607,7 +628,7 @@ function add_source_packages_to_manifest(
 end
 
 """
-    resolve_directory(dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs)
+    resolve_directory(dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs, no_promote)
 
 Resolve dependencies for a single directory. Handles source packages by temporarily
 removing them from the project file, running the resolver, and then restoring the original.
@@ -615,7 +636,8 @@ Returns the source packages found in the directory (for use in forcedeps checkin
 """
 function resolve_directory(
         dir::AbstractString, resolver_path::AbstractString, resolver_mode::AbstractString,
-        julia_version::AbstractString, mode::AbstractString, ignore_pkgs)
+        julia_version::AbstractString, mode::AbstractString, ignore_pkgs,
+        no_promote = String[])
     project_files = [joinpath(dir, "Project.toml"), joinpath(dir, "JuliaProject.toml")]
     filter!(isfile, project_files)
     isempty(project_files) &&
@@ -629,7 +651,7 @@ function resolve_directory(
     if haskey(project, "extras") && haskey(project, "targets") && haskey(project["targets"], "test")
         @info "Project $dir has [extras] and [targets].test, using merged resolution"
         merged_dir = mktempdir()
-        source_pkgs = create_merged_project(project_file, project_file, merged_dir)
+        source_pkgs = create_merged_project(project_file, project_file, merged_dir; no_promote)
 
         try
             @info "Running resolver on merged project (extras) for $dir with --min=@$resolver_mode"
@@ -920,7 +942,7 @@ if do_merge
 
     # Create merged project in temp directory
     merged_dir = mktempdir()
-    source_pkgs = create_merged_project(main_project_file, test_project_file, merged_dir)
+    source_pkgs = create_merged_project(main_project_file, test_project_file, merged_dir; no_promote)
 
     # Run resolver on merged project
     @info "Running resolver on merged project with --min=@$resolver_mode"
@@ -985,12 +1007,12 @@ if do_merge
     other_dirs = filter(d -> normpath(d) != main_dir && normpath(d) != test_dir, dirs)
     for dir in other_dirs
         resolve_directory(
-            dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs)
+            dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs, no_promote)
     end
 else
     # Independent resolution: process each directory separately
     for dir in dirs
         resolve_directory(
-            dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs)
+            dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs, no_promote)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -971,4 +971,69 @@ end
             end
         end
     end
+
+    @testset "no_promote keeps a named weakdep extension out of the joint resolve" begin
+        # The merged resolution promotes every weakdep test-extra into ONE joint
+        # floor-resolve -- correct, because the extensions coexist in a single test
+        # env. A backend that is currently unresolvable on its own (here a nonexistent
+        # floor, standing in for Mooncake, whose graph Resolver.jl cannot --min-resolve)
+        # makes that joint resolve fail. Naming it in `no_promote` (the 5th arg) keeps
+        # it a weakdep so it is never promoted; the joint resolve then succeeds and
+        # every OTHER extension is still floor-tested together.
+        write_repro() = begin
+            write(
+                "Project.toml",
+                """
+                name = "ReproPkg"
+                uuid = "598b003f-0677-49cf-8d2a-39b1658b755a"
+                version = "0.1.0"
+
+                [deps]
+                DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                [weakdeps]
+                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                [extensions]
+                ReproJSONExt = "JSON"
+
+                [compat]
+                julia = "1.10"
+                DataStructures = "0.17, 0.18"
+                JSON = "0.999"
+
+                [extras]
+                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                [targets]
+                test = ["JSON"]
+                """,
+            )
+            mkdir("src")
+            write("src/ReproPkg.jl", "module ReproPkg\nend\n")
+        end
+
+        # Without no_promote: JSON is promoted, and its unsatisfiable floor fails the run.
+        mktempdir() do dir
+            cd(dir) do
+                write_repro()
+                @test_throws ProcessFailedException run(
+                    pipeline(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`;
+                        stdout = devnull, stderr = devnull))
+            end
+        end
+
+        # With no_promote=JSON: JSON stays a weakdep, the joint resolve succeeds, and
+        # JSON is absent from the resolved [deps] (DataStructures is still minimized).
+        mktempdir() do dir
+            cd(dir) do
+                write_repro()
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10" "JSON"`)
+                @test isfile("Manifest.toml")
+                deps = TOML.parsefile("Manifest.toml")["deps"]
+                @test startswith(deps["DataStructures"][1]["version"], "0.17")
+                @test !haskey(deps, "JSON")
+            end
+        end
+    end
 end


### PR DESCRIPTION
## Problem

In merged resolution (old-style `[extras]` + `[targets].test`), the action promotes **every** weakdep test-extra into one merged `[deps]` and floor-resolves them together with `Resolver.jl --min`. That joint floor-test is **correct** — the extensions all coexist in a single test environment, so they should be resolved together.

The only real problem is one backend that is currently unresolvable on its own: **Mooncake**, whose dependency graph `Resolver.jl` cannot `--min`-resolve at all (**StefanKarpinski/Resolver.jl#24** — Pkg resolves the identical graph fine). When Mooncake is in the joint resolve, the whole merged `--min` errors `Unsatisfiable` (and it's registry-fragile — the same commit flips `UNSAT`↔`SAT` as packages release). This is the fleet-wide SciML Downgrade red.

## Fix (minimal, conservative)

Add a **`no_promote`** input (comma-separated; new 5th script arg / action input, default empty). A test-extra that is also a `[weakdeps]` entry **and** named in `no_promote` is kept as a weakdep instead of being promoted — it installs at latest during instantiate and is never force-min-resolved. **Every other weakdep extension is still promoted and floor-tested jointly**, exactly as before.

So `no_promote: Mooncake` drops just Mooncake from the joint resolve → it succeeds → the Downgrade lane goes green, while every other extension's floor is still exercised together. It's the smallest possible change that greens the lane, and it's opt-in per repo.

Threaded through `create_merged_project` (both the old-style and the workspace-merge paths).

## Validation

- The otherwise-unsatisfiable `JSON = "0.999"` extension **fails** the joint resolve when promoted (stock behavior), and **succeeds** — kept as a weakdep, absent from the resolved `[deps]` — when named in `no_promote`.
- **Suite 105/105.**

Sits on top of current `main` (includes #51). Companion: **SciML/.github#106** wires `no_promote: Mooncake` as the reusable `downgrade.yml` default so the whole SciML fleet goes green once this releases.

Draft — ignore until reviewed by @ChrisRackauckas.