### PR TITLE
no_promote: also exclude a named PURE test-extra (not just weakdeps)

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -267,18 +267,20 @@ function create_merged_project(main_project_file::String, test_project_file::Str
     # legacy extras in the root project that might still be used are included.
     # For the "old style" case where test_project_file == main_project_file,
     # this is where the test dependencies are actually added to [deps].
-    main_weakdeps = get(main_project, "weakdeps", Dict())
     if haskey(main_project, "extras")
         deps = get!(merged, "deps", Dict{String, Any}())
         for (pkg, uuid) in main_project["extras"]
             if pkg ∉ source_pkgs
-                # A weakdep extension named in `no_promote` is left as a weakdep
-                # (installed at latest, never force-min-resolved), instead of being
-                # promoted into the joint floor-resolve. Used to exclude a backend
-                # that is currently unresolvable on its own (e.g. Mooncake); every
-                # other extension is still promoted and floor-tested together.
-                if pkg in no_promote && haskey(main_weakdeps, pkg)
-                    @info "Keeping $pkg as a weakdep in merged project (listed in no_promote)"
+                # An extra named in `no_promote` is NOT promoted into the merged
+                # [deps], so it is excluded from the joint floor-resolve. A weakdep
+                # extra stays a weakdep; a pure test extra stays in [extras]; either
+                # way it is installed at latest and never force-min-resolved. Used to
+                # exclude a backend that is currently unresolvable on its own (e.g.
+                # Mooncake); every other extension is still promoted and floor-tested
+                # together. (Not gated on [weakdeps] membership: some repos list an AD
+                # backend only in [extras]/[targets].test with no [weakdeps] section.)
+                if pkg in no_promote
+                    @info "Not promoting $pkg into merged [deps] (listed in no_promote)"
                     continue
                 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1036,4 +1036,61 @@ end
             end
         end
     end
+
+    @testset "no_promote also excludes a PURE test-extra (no [weakdeps])" begin
+        # Some repos list an AD backend only in [extras]/[targets].test with NO
+        # [weakdeps] section (e.g. Optimization.jl's root). `no_promote` must exclude
+        # it from promotion too, not just weakdep extras -- otherwise the joint resolve
+        # still promotes the unresolvable backend. Here JSON is a pure extra (no
+        # [weakdeps]/[extensions]) with a nonexistent floor.
+        write_repro() = begin
+            write(
+                "Project.toml",
+                """
+                name = "ReproPkg"
+                uuid = "598b003f-0677-49cf-8d2a-39b1658b755a"
+                version = "0.1.0"
+
+                [deps]
+                DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                [compat]
+                julia = "1.10"
+                DataStructures = "0.17, 0.18"
+                JSON = "0.999"
+
+                [extras]
+                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                [targets]
+                test = ["JSON"]
+                """,
+            )
+            mkdir("src")
+            write("src/ReproPkg.jl", "module ReproPkg\nend\n")
+        end
+
+        # Without no_promote: the pure extra JSON is promoted -> unsatisfiable -> fails.
+        mktempdir() do dir
+            cd(dir) do
+                write_repro()
+                @test_throws ProcessFailedException run(
+                    pipeline(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`;
+                        stdout = devnull, stderr = devnull))
+            end
+        end
+
+        # With no_promote=JSON: the pure extra is not promoted, the resolve succeeds,
+        # and JSON is absent from the resolved [deps].
+        mktempdir() do dir
+            cd(dir) do
+                write_repro()
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10" "JSON"`)
+                @test isfile("Manifest.toml")
+                deps = TOML.parsefile("Manifest.toml")["deps"]
+                @test startswith(deps["DataStructures"][1]["version"], "0.17")
+                @test !haskey(deps, "JSON")
+            end
+        end
+    end
 end


### PR DESCRIPTION
## Problem

`no_promote` (v2.6.0, #52) skips promoting a named weakdep extension into the merged joint resolve — but it was gated on the name being a `[weakdeps]` entry. Some repos list an AD backend only in `[extras]`/`[targets].test` with **no `[weakdeps]` section at all** (e.g. `Optimization.jl`'s root lists `Mooncake` as a pure test extra). There, the fleet default `no_promote: Mooncake` did nothing — the joint resolve still promoted Mooncake, whose graph `Resolver.jl` can't `--min`-resolve, so the Downgrade lane stayed red on unlucky registry snapshots.

## Fix

Drop the `haskey(main_weakdeps, pkg)` guard. A name in `no_promote` is never promoted into the merged `[deps]`, whether it's a weakdep extra (stays a weakdep) or a pure test extra (stays in `[extras]`). Either way it's excluded from the joint floor-resolve and installed at latest at test time. Every other extension is still promoted and floor-tested together.

## Validation

Adds a pure-extra test: an `[extras]`-only backend with an unsatisfiable floor **fails** the joint resolve when promoted, and **succeeds** (excluded, absent from resolved `[deps]`) when named in `no_promote`. **Suite 109/109.**

Follow-up to #52 / v2.6.0. Draft — ignore until reviewed by @ChrisRackauckas.
