### PR TITLE
Re-add direct path sources to merged manifests

### DIFF
--- a/downgrade.jl
+++ b/downgrade.jl
@@ -535,7 +535,7 @@ function set_manifest_project_hash(manifest_file::String, project_file::String)
 end
 
 """
-    add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
+    add_source_packages_to_manifest(manifest_file, project_file, manifest_dir, source_pkgs)
 
 Re-add local path-sourced packages to `manifest_file` after resolution.
 
@@ -560,7 +560,7 @@ dependency on ... is ambiguous". The path source must win, since that is the
 whole point of the `[sources]` override.
 """
 function add_source_packages_to_manifest(
-        manifest_file::String, project_file::String, dir::AbstractString, source_pkgs)
+        manifest_file::String, project_file::String, manifest_dir::AbstractString, source_pkgs)
     isempty(source_pkgs) && return
     if !isfile(manifest_file)
         @warn "Manifest file not found: $manifest_file"
@@ -570,6 +570,8 @@ function add_source_packages_to_manifest(
     project = TOML.parsefile(project_file)
     sources = get(project, "sources", Dict())
     deps = get(project, "deps", Dict())
+    project_dir = dirname(abspath(project_file))
+    manifest_dir = abspath(manifest_dir)
 
     entry_lines = String[]
     added_pkgs = String[]
@@ -580,16 +582,20 @@ function add_source_packages_to_manifest(
         src = get(sources, pkg, nothing)
         (src isa Dict && haskey(src, "path")) || continue
 
-        pkg_path = src["path"]
-        candidates = [joinpath(dir, pkg_path, "Project.toml"),
-                      joinpath(dir, pkg_path, "JuliaProject.toml")]
+        source_path = normpath(joinpath(project_dir, src["path"]))
+        pkg_path = relpath(source_path, manifest_dir)
+        candidates = [joinpath(source_path, "Project.toml"),
+                      joinpath(source_path, "JuliaProject.toml")]
         filter!(isfile, candidates)
         uuid = get(deps, pkg, nothing)
         version = nothing
+        hard_deps = String[]
         if !isempty(candidates)
             pkg_project = TOML.parsefile(first(candidates))
             uuid = get(pkg_project, "uuid", uuid)
             version = get(pkg_project, "version", nothing)
+            append!(hard_deps, keys(get(pkg_project, "deps", Dict{String, Any}())))
+            sort!(hard_deps)
         end
         if uuid === nothing
             @warn "Could not determine uuid for source package $pkg, skipping manifest entry"
@@ -597,6 +603,7 @@ function add_source_packages_to_manifest(
         end
 
         push!(entry_lines, "[[deps.$pkg]]")
+        isempty(hard_deps) || push!(entry_lines, "deps = $(repr(hard_deps))")
         push!(entry_lines, "path = \"$pkg_path\"")
         push!(entry_lines, "uuid = \"$uuid\"")
         version !== nothing && push!(entry_lines, "version = \"$version\"")
@@ -966,6 +973,18 @@ if do_merge
         # This is needed for workspace projects where the test project depends on the main package
         add_main_package_to_manifest(main_manifest, main_project_file; path = ".")
         add_main_package_to_manifest(test_manifest, main_project_file; path = "..")
+        main_source_pkgs = get_source_packages(main_project_file)
+        test_source_pkgs = get_source_packages(test_project_file)
+        for (manifest, manifest_dir) in (
+                (main_manifest, main_dir), (test_manifest, test_dir)
+            )
+            add_source_packages_to_manifest(
+                manifest, main_project_file, manifest_dir, main_source_pkgs
+            )
+            add_source_packages_to_manifest(
+                manifest, test_project_file, manifest_dir, test_source_pkgs
+            )
+        end
 
         # Ensure each manifest has the project hash corresponding to the project
         # that will consume it (main root and test environment respectively).

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -972,6 +972,96 @@ end
         end
     end
 
+    @testset "split projects rebase direct path sources in both locked manifests" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalDep/src")
+                write(
+                    "LocalDep/Project.toml",
+                    """
+                    name = "LocalDep"
+                    uuid = "99999999-9999-9999-9999-999999999999"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [compat]
+                    JSON = "0.21"
+                    """
+                )
+                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing JSON\nend\n")
+
+                mkpath("src")
+                mkpath("test")
+                write("src/RootPkg.jl", "module RootPkg\nusing LocalDep\nend\n")
+                write(
+                    "test/runtests.jl",
+                    "using Test, BenchmarkTools, RootPkg\n@test true\n"
+                )
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    LocalDep = "99999999-9999-9999-9999-999999999999"
+
+                    [sources]
+                    LocalDep = {path = "LocalDep"}
+
+                    [compat]
+                    julia = "1.10"
+                    JSON = "0.21.4"
+                    LocalDep = "0.1"
+                    """
+                )
+                write(
+                    "test/Project.toml",
+                    """
+                    [deps]
+                    BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+                    RootPkg = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+                    [sources]
+                    RootPkg = {path = ".."}
+
+                    [compat]
+                    BenchmarkTools = "1.5.0"
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" ".,test" "alldeps" "1"`)
+
+                main_manifest = TOML.parsefile("Manifest.toml")
+                test_manifest = TOML.parsefile("test/Manifest.toml")
+                main_deps = main_manifest["deps"]
+                test_deps = test_manifest["deps"]
+                @test only(main_deps["JSON"])["version"] == "0.21.4"
+                @test only(main_deps["BenchmarkTools"])["version"] == "1.5.0"
+                @test only(main_deps["LocalDep"])["path"] == "LocalDep"
+                @test Set(only(main_deps["LocalDep"])["deps"]) == Set(["JSON"])
+                @test only(test_deps["LocalDep"])["path"] == "../LocalDep"
+                @test only(main_deps["RootPkg"])["path"] == "."
+                @test only(test_deps["RootPkg"])["path"] == ".."
+                @test Set(only(test_deps["RootPkg"])["deps"]) == Set(["JSON", "LocalDep"])
+
+                locked = Dict(
+                    name => only(test_deps[name])["version"]
+                    for name in ("BenchmarkTools", "JSON")
+                )
+                run(`$(Base.julia_cmd()) --project=test -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'`)
+                after = TOML.parsefile("test/Manifest.toml")["deps"]
+                @test locked == Dict(
+                    name => only(after[name])["version"] for name in keys(locked)
+                )
+            end
+        end
+    end
+
     @testset "no_promote keeps a named weakdep extension out of the joint resolve" begin
         # The merged resolution promotes every weakdep test-extra into ONE joint
         # floor-resolve -- correct, because the extensions coexist in a single test


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Summary

- re-add direct local path sources to both manifests produced by a merged root/test resolution
- rebase each source path relative to the manifest that consumes it
- preserve the path package's hard dependency metadata in the generated manifest entry

## Why

Merged resolution currently restores only the main package. Other direct `[sources]` path packages can disappear from the copied manifests, and a path declared by `test/Project.toml` can be written relative to the wrong directory. That leaves the locked downstream environment incomplete even when every registry dependency was already part of the resolution.

This is the focused manifest-reconstruction layer related to #39. The stacked follow-up #55 makes hard registry dependencies declared only by a direct path package participate in minimum-version resolution; that behavior is intentionally kept out of this review diff.

## Validation

- `julia +1.10 --startup-file=no test/runtests.jl`
  - 118/118 passed in 9m43.1s
- focused split-project regression: 9/9 passed
- `git diff --check`
- GitHub CI passed on Julia 1.10 and current Julia

## Process

1. Reproduced the split root/test source-manifest gap with a local fixture.
2. Rebasing source paths against each consuming manifest fixed the main/test path mismatch.
3. Restoring both projects' direct sources and their hard dependency lists made the generated locked manifests instantiable without changing resolved registry versions.

## Stack

This is the base patch. #55 is stacked on this PR and should be reviewed and merged afterward.
