### PR TITLE
[Stacked on #54] Resolve direct path-source dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ For Julia `>= 1.12`, using `julia-actions/julia-runtest` with
 When possible, run the action on the same Julia version that you pass as `julia_version`.
 Cross-runtime resolution may fail; matching runtime and target version is recommended and the default for `julia_version`.
 
+### Local path sources
+
+For a direct runtime dependency configured with `[sources]` and `path`, the
+action includes hard registry dependencies that are declared by the local
+package but missing from the active project in the minimum-version resolution.
+Dependencies already declared by the active project retain their compat floor;
+the subsequent locked build and test validate that floor against the local
+package. If two direct path packages add the same missing dependency, their UUID
+and compat strings must match or the action fails.
+
+This support is intentionally limited to direct path packages. It does not
+traverse nested path sources, promote their weak dependencies, or intersect
+different compat strings for an existing project dependency.
+
 ## Downgrade Modes
 
 - **`deps`**: Minimize only your direct dependencies (recommended for most packages)

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -535,7 +535,7 @@ function set_manifest_project_hash(manifest_file::String, project_file::String)
 end
 
 """
-    add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
+    add_source_packages_to_manifest(manifest_file, project_file, manifest_dir, source_pkgs)
 
 Re-add local path-sourced packages to `manifest_file` after resolution.
 
@@ -560,7 +560,7 @@ dependency on ... is ambiguous". The path source must win, since that is the
 whole point of the `[sources]` override.
 """
 function add_source_packages_to_manifest(
-        manifest_file::String, project_file::String, dir::AbstractString, source_pkgs)
+        manifest_file::String, project_file::String, manifest_dir::AbstractString, source_pkgs)
     isempty(source_pkgs) && return
     if !isfile(manifest_file)
         @warn "Manifest file not found: $manifest_file"
@@ -570,6 +570,8 @@ function add_source_packages_to_manifest(
     project = TOML.parsefile(project_file)
     sources = get(project, "sources", Dict())
     deps = get(project, "deps", Dict())
+    project_dir = dirname(abspath(project_file))
+    manifest_dir = abspath(manifest_dir)
 
     entry_lines = String[]
     added_pkgs = String[]
@@ -580,16 +582,20 @@ function add_source_packages_to_manifest(
         src = get(sources, pkg, nothing)
         (src isa Dict && haskey(src, "path")) || continue
 
-        pkg_path = src["path"]
-        candidates = [joinpath(dir, pkg_path, "Project.toml"),
-                      joinpath(dir, pkg_path, "JuliaProject.toml")]
+        source_path = normpath(joinpath(project_dir, src["path"]))
+        pkg_path = relpath(source_path, manifest_dir)
+        candidates = [joinpath(source_path, "Project.toml"),
+                      joinpath(source_path, "JuliaProject.toml")]
         filter!(isfile, candidates)
         uuid = get(deps, pkg, nothing)
         version = nothing
+        hard_deps = String[]
         if !isempty(candidates)
             pkg_project = TOML.parsefile(first(candidates))
             uuid = get(pkg_project, "uuid", uuid)
             version = get(pkg_project, "version", nothing)
+            append!(hard_deps, keys(get(pkg_project, "deps", Dict{String, Any}())))
+            sort!(hard_deps)
         end
         if uuid === nothing
             @warn "Could not determine uuid for source package $pkg, skipping manifest entry"
@@ -597,6 +603,7 @@ function add_source_packages_to_manifest(
         end
 
         push!(entry_lines, "[[deps.$pkg]]")
+        isempty(hard_deps) || push!(entry_lines, "deps = $(repr(hard_deps))")
         push!(entry_lines, "path = \"$pkg_path\"")
         push!(entry_lines, "uuid = \"$uuid\"")
         version !== nothing && push!(entry_lines, "version = \"$version\"")
@@ -966,6 +973,18 @@ if do_merge
         # This is needed for workspace projects where the test project depends on the main package
         add_main_package_to_manifest(main_manifest, main_project_file; path = ".")
         add_main_package_to_manifest(test_manifest, main_project_file; path = "..")
+        main_source_pkgs = get_source_packages(main_project_file)
+        test_source_pkgs = get_source_packages(test_project_file)
+        for (manifest, manifest_dir) in (
+                (main_manifest, main_dir), (test_manifest, test_dir)
+            )
+            add_source_packages_to_manifest(
+                manifest, main_project_file, manifest_dir, main_source_pkgs
+            )
+            add_source_packages_to_manifest(
+                manifest, test_project_file, manifest_dir, test_source_pkgs
+            )
+        end
 
         # Ensure each manifest has the project hash corresponding to the project
         # that will consume it (main root and test environment respectively).

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -139,83 +139,149 @@ function get_source_packages(project_file::String)
     return source_pkgs
 end
 
-"""
-    remove_source_packages_from_project(project_file, source_pkgs)
+struct DirectRuntimePathSource
+    name::String
+    project::Dict{String, Any}
+end
 
-Create a modified version of the Project.toml with source packages
-removed from [deps], [compat], [extras], [sources], and [targets] sections.
-Returns the original content so it can be restored later.
-
-Note: We must also remove from [sources] because Pkg validates that any
-package in [sources] must be in [deps] or [extras]; and from [targets]
-because Pkg validates that any package in a target must be in [deps],
-[weakdeps], or [extras]. A source package that also appears in a test
-target (common in monorepos that dev a sibling package for testing) would
-otherwise leave a dangling target reference once removed from [extras].
-"""
-function remove_source_packages_from_project(project_file::String, source_pkgs::Set{String})
-    if isempty(source_pkgs)
-        return nothing  # No modification needed
+function find_project_file(dir::AbstractString)
+    for filename in ("Project.toml", "JuliaProject.toml")
+        project_file = joinpath(dir, filename)
+        isfile(project_file) && return project_file
     end
-
-    original_content = read(project_file, String)
-    project = TOML.parsefile(project_file)
-    modified = false
-
-    # Remove from [deps], [extras], [compat], and [sources]
-    for section_name in ("deps", "extras", "compat", "sources")
-        haskey(project, section_name) || continue
-        section = project[section_name]
-        for pkg in source_pkgs
-            haskey(section, pkg) || continue
-            delete!(section, pkg)
-            modified = true
-            @info "Temporarily removing $pkg from [$section_name] for resolution"
-        end
-    end
-
-    # Remove from each list in [targets]. A source package removed from [extras]
-    # above but left in a target would fail Pkg validation ("Dependency X in
-    # target test not listed in deps, weakdeps or extras") before resolution runs.
-    if haskey(project, "targets")
-        for (target_name, target_list) in project["targets"]
-            target_list isa AbstractVector || continue
-            for pkg in source_pkgs
-                if pkg in target_list
-                    filter!(!isequal(pkg), target_list)
-                    modified = true
-                    @info "Temporarily removing $pkg from [targets.$target_name] for resolution"
-                end
-            end
-        end
-    end
-
-    # Remove empty [sources] section
-    if haskey(project, "sources") && isempty(project["sources"])
-        delete!(project, "sources")
-    end
-
-    if modified
-        open(project_file, "w") do io
-            TOML.print(io, project)
-        end
-        return original_content
-    end
-
     return nothing
 end
 
 """
-    restore_project_file(project_file, original_content)
+    collect_direct_runtime_path_sources(project_file) -> Vector{DirectRuntimePathSource}
 
-Restore the original Project.toml content after resolution.
+Collect direct local path packages that occur in both runtime `[deps]` and
+`[sources]` in `project_file`. Nested path sources are intentionally not
+traversed.
 """
-function restore_project_file(project_file::String, original_content::Union{
-        String, Nothing})
-    if original_content !== nothing
-        write(project_file, original_content)
-        @info "Restored original Project.toml"
+function collect_direct_runtime_path_sources(project_file::String)
+    root_file = abspath(project_file)
+    root_dir = dirname(root_file)
+    root_project = TOML.parsefile(root_file)
+    deps = get(root_project, "deps", Dict{String, Any}())
+    sources = get(root_project, "sources", Dict{String, Any}())
+    result = DirectRuntimePathSource[]
+
+    for name in sort!(collect(keys(sources)))
+        haskey(deps, name) || continue
+        source = sources[name]
+        source isa AbstractDict || continue
+        haskey(source, "path") || continue
+
+        source_dir = normpath(abspath(joinpath(root_dir, source["path"])))
+        source_file = find_project_file(source_dir)
+        source_file === nothing &&
+            error("Path source $name from $root_file has no project file at $source_dir")
+        source_project = TOML.parsefile(source_file)
+        declared_name = get(source_project, "name", name)
+        declared_name == name ||
+            error("Path source $name from $root_file declares package name $declared_name")
+        declared_uuid = get(source_project, "uuid", nothing)
+        declared_uuid == deps[name] || error(
+            "Path source $name from $root_file has uuid $declared_uuid, expected $(deps[name])"
+        )
+        push!(result, DirectRuntimePathSource(name, source_project))
     end
+
+    return result
+end
+
+"""
+    add_direct_path_source_dependencies!(merged, project_files)
+
+Add hard registry dependencies that are missing from `merged` but required by a
+direct runtime path source in `project_files`. Dependencies already owned by the
+root project keep the root UUID and compat unchanged. When two path sources add
+the same missing dependency, their UUIDs and any compat strings must agree.
+
+This intentionally does not traverse nested path sources, include dependencies
+from a path package's `[weakdeps]`, or intersect differing compat specifications.
+The locked package build and tests remain responsible for validating root-owned
+dependency versions against the path package.
+"""
+function add_direct_path_source_dependencies!(merged, project_files::Vector{String})
+    path_sources = reduce(
+        vcat, collect_direct_runtime_path_sources.(project_files);
+        init = DirectRuntimePathSource[]
+    )
+    isempty(path_sources) && return
+
+    deps = get!(merged, "deps", Dict{String, Any}())
+    compat = get!(merged, "compat", Dict{String, Any}())
+    weakdeps = get(merged, "weakdeps", Dict{String, Any}())
+    root_owned = Set(keys(deps))
+    local_source_names = Set(source.name for source in path_sources)
+    promoted_by = Dict{String, String}()
+
+    for source in path_sources
+        source_deps = get(source.project, "deps", Dict{String, Any}())
+        source_compat = get(source.project, "compat", Dict{String, Any}())
+        for name in sort!(collect(keys(source_deps)))
+            uuid = source_deps[name]
+            if name in local_source_names
+                @info "Leaving direct path dependency $name local while reading $(source.name)"
+                continue
+            end
+
+            if name in root_owned
+                deps[name] == uuid || error(
+                    "Root dependency $name has uuid $(deps[name]), but path source " *
+                    "$(source.name) requires $uuid"
+                )
+                continue
+            end
+
+            if haskey(weakdeps, name)
+                weakdeps[name] == uuid || error(
+                    "Root weak dependency $name has uuid $(weakdeps[name]), but path " *
+                    "source $(source.name) requires $uuid"
+                )
+                deps[name] = uuid
+                delete!(weakdeps, name)
+                isempty(weakdeps) && delete!(merged, "weakdeps")
+                push!(root_owned, name)
+                @info "Promoting root weak dependency required by $(source.name): $name"
+                continue
+            end
+
+            constraint = get(source_compat, name, nothing)
+            if haskey(promoted_by, name)
+                deps[name] == uuid || error(
+                    "Path sources $(promoted_by[name]) and $(source.name) require " *
+                    "$name with different uuids $(deps[name]) and $uuid"
+                )
+                if constraint !== nothing && haskey(compat, name) &&
+                        compat[name] != constraint
+                    error(
+                        "Path sources $(promoted_by[name]) and $(source.name) require " *
+                        "$name with different compat entries $(compat[name]) and $constraint"
+                    )
+                elseif constraint !== nothing
+                    compat[name] = constraint
+                end
+                continue
+            end
+
+            deps[name] = uuid
+            promoted_by[name] = source.name
+            if constraint !== nothing
+                if haskey(compat, name) && compat[name] != constraint
+                    error(
+                        "Project compat for promoted dependency $name is $(compat[name]), " *
+                        "but path source $(source.name) requires $constraint"
+                    )
+                end
+                compat[name] = constraint
+            end
+            @info "Adding runtime dependency from direct path source $(source.name): $name"
+        end
+    end
+    return
 end
 
 """
@@ -250,8 +316,7 @@ function create_merged_project(main_project_file::String, test_project_file::Str
     # own unregistered lib/* sources). The merge logic below already skips ADDING
     # source packages from extras/test-deps, but a source package listed directly
     # in the main project's [deps] (a monorepo root depending on its siblings)
-    # would otherwise survive the deepcopy. This mirrors the non-merged path's
-    # remove_source_packages_from_project. They are re-added to the manifest as
+    # would otherwise survive the deepcopy. They are re-added to the manifest as
     # path deps after resolution (add_source_packages_to_manifest).
     for section_name in ("deps", "compat", "sources")
         if haskey(merged, section_name)
@@ -356,6 +421,10 @@ function create_merged_project(main_project_file::String, test_project_file::Str
     if haskey(merged, "weakdeps") && isempty(merged["weakdeps"])
         delete!(merged, "weakdeps")
     end
+
+    project_files = main_project_file == test_project_file ?
+                    [main_project_file] : [main_project_file, test_project_file]
+    add_direct_path_source_dependencies!(merged, project_files)
 
     # Write merged project
     mkpath(merged_dir)
@@ -549,8 +618,7 @@ written back as a path dependency pointing at the same location given in
 
 Note: only packages that are themselves in `[deps]` need to be in this manifest;
 packages sourced solely for a test target are not part of the resolved
-environment. The path packages' own (unique) transitive dependencies are not
-re-resolved here, so a fully locked test of those is out of scope for this step.
+environment. Nested path sources are not followed.
 
 If the resolver already emitted a registry entry for a source package (which
 happens whenever another resolved package depends on it), that entry is removed
@@ -639,8 +707,8 @@ end
 """
     resolve_directory(dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs, no_promote)
 
-Resolve dependencies for a single directory. Handles source packages by temporarily
-removing them from the project file, running the resolver, and then restoring the original.
+Resolve dependencies for a single directory. Source packages are omitted from a
+temporary merged project and restored to the resolved manifest as path entries.
 Returns the source packages found in the directory (for use in forcedeps checking).
 """
 function resolve_directory(
@@ -683,24 +751,26 @@ function resolve_directory(
             rm(merged_dir, recursive = true)
         end
     else
-        # Handle packages with [sources] entries (e.g., test/Project.toml referencing main package)
-        # These packages cannot be resolved from the registry, so we temporarily remove them
         source_pkgs = get_source_packages(project_file)
-        original_content = remove_source_packages_from_project(project_file, source_pkgs)
-
-        try
+        if isempty(source_pkgs)
             @info "Running resolver on $dir with --min=@$resolver_mode"
             run(`$(Base.julia_cmd()) --project=$resolver_path/bin $resolver_path/bin/resolve.jl $dir --min=@$resolver_mode --julia=$julia_version`)
             @info "Successfully resolved minimal versions for $dir"
-        finally
-            # Always restore the original Project.toml, even if resolution fails
-            restore_project_file(project_file, original_content)
-        end
+        else
+            merged_dir = mktempdir()
+            source_pkgs = create_merged_project(
+                project_file, project_file, merged_dir; no_promote
+            )
+            try
+                @info "Running resolver on $dir with path-source constraints and --min=@$resolver_mode"
+                run(`$(Base.julia_cmd()) --project=$resolver_path/bin $resolver_path/bin/resolve.jl $merged_dir --min=@$resolver_mode --julia=$julia_version`)
+                @info "Successfully resolved minimal versions for $dir with path-source constraints"
+                merged_manifest = joinpath(merged_dir, "Manifest.toml")
+                isfile(merged_manifest) && cp(merged_manifest, manifest_file; force = true)
+            finally
+                rm(merged_dir, recursive = true)
+            end
 
-        # Re-add local path-sourced packages (removed for resolution) to the manifest
-        # so the resolved environment is complete enough to instantiate/build (#3021),
-        # then refresh the project hash so Pkg sees the manifest as up to date.
-        if !isempty(source_pkgs)
             add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
         end
         set_manifest_project_hash(manifest_file, project_file)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -972,6 +972,96 @@ end
         end
     end
 
+    @testset "split projects rebase direct path sources in both locked manifests" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalDep/src")
+                write(
+                    "LocalDep/Project.toml",
+                    """
+                    name = "LocalDep"
+                    uuid = "99999999-9999-9999-9999-999999999999"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [compat]
+                    JSON = "0.21"
+                    """
+                )
+                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing JSON\nend\n")
+
+                mkpath("src")
+                mkpath("test")
+                write("src/RootPkg.jl", "module RootPkg\nusing LocalDep\nend\n")
+                write(
+                    "test/runtests.jl",
+                    "using Test, BenchmarkTools, RootPkg\n@test true\n"
+                )
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    LocalDep = "99999999-9999-9999-9999-999999999999"
+
+                    [sources]
+                    LocalDep = {path = "LocalDep"}
+
+                    [compat]
+                    julia = "1.10"
+                    JSON = "0.21.4"
+                    LocalDep = "0.1"
+                    """
+                )
+                write(
+                    "test/Project.toml",
+                    """
+                    [deps]
+                    BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+                    RootPkg = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+                    [sources]
+                    RootPkg = {path = ".."}
+
+                    [compat]
+                    BenchmarkTools = "1.5.0"
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" ".,test" "alldeps" "1"`)
+
+                main_manifest = TOML.parsefile("Manifest.toml")
+                test_manifest = TOML.parsefile("test/Manifest.toml")
+                main_deps = main_manifest["deps"]
+                test_deps = test_manifest["deps"]
+                @test only(main_deps["JSON"])["version"] == "0.21.4"
+                @test only(main_deps["BenchmarkTools"])["version"] == "1.5.0"
+                @test only(main_deps["LocalDep"])["path"] == "LocalDep"
+                @test Set(only(main_deps["LocalDep"])["deps"]) == Set(["JSON"])
+                @test only(test_deps["LocalDep"])["path"] == "../LocalDep"
+                @test only(main_deps["RootPkg"])["path"] == "."
+                @test only(test_deps["RootPkg"])["path"] == ".."
+                @test Set(only(test_deps["RootPkg"])["deps"]) == Set(["JSON", "LocalDep"])
+
+                locked = Dict(
+                    name => only(test_deps[name])["version"]
+                    for name in ("BenchmarkTools", "JSON")
+                )
+                run(`$(Base.julia_cmd()) --project=test -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'`)
+                after = TOML.parsefile("test/Manifest.toml")["deps"]
+                @test locked == Dict(
+                    name => only(after[name])["version"] for name in keys(locked)
+                )
+            end
+        end
+    end
+
     @testset "no_promote keeps a named weakdep extension out of the joint resolve" begin
         # The merged resolution promotes every weakdep test-extra into ONE joint
         # floor-resolve -- correct, because the extensions coexist in a single test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -972,6 +972,121 @@ end
         end
     end
 
+    @testset "direct path-source runtime dependencies participate in minimum resolution" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalA/src")
+                write(
+                    "LocalA/Project.toml",
+                    """
+                    name = "LocalA"
+                    uuid = "11111111-1111-1111-1111-111111111111"
+                    version = "0.1.0"
+
+                    [deps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+                    [compat]
+                    DataStructures = "0.18"
+                    julia = "1.10"
+                    JSON = "0.21"
+                    StaticArrays = "1.9.8"
+                    """
+                )
+                write(
+                    "LocalA/src/LocalA.jl",
+                    "module LocalA\nusing DataStructures, JSON, StaticArrays\nend\n"
+                )
+
+                mkpath("LocalB/src")
+                write(
+                    "LocalB/Project.toml",
+                    """
+                    name = "LocalB"
+                    uuid = "22222222-2222-2222-2222-222222222222"
+                    version = "0.1.0"
+
+                    [deps]
+                    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+                    [compat]
+                    julia = "1.10"
+                    StaticArrays = "1.9.8"
+                    """
+                )
+                write("LocalB/src/LocalB.jl", "module LocalB\nusing StaticArrays\nend\n")
+
+                mkpath("src")
+                mkpath("test")
+                write("src/RootPkg.jl", "module RootPkg\nusing LocalA, LocalB\nend\n")
+                write(
+                    "test/runtests.jl",
+                    "using Test, BenchmarkTools, RootPkg\n@test true\n"
+                )
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "33333333-3333-3333-3333-333333333333"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    LocalA = "11111111-1111-1111-1111-111111111111"
+                    LocalB = "22222222-2222-2222-2222-222222222222"
+
+                    [sources]
+                    LocalA = {path = "LocalA"}
+                    LocalB = {path = "LocalB"}
+
+                    [compat]
+                    DataStructures = "0.18.0"
+                    julia = "1.10"
+                    BenchmarkTools = "1.5.0"
+                    JSON = "0.21.4"
+                    LocalA = "0.1"
+                    LocalB = "0.1"
+
+                    [weakdeps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [extras]
+                    BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+                    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+                    [targets]
+                    test = ["BenchmarkTools", "Test"]
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "alldeps" "1"`)
+
+                manifest = TOML.parsefile("Manifest.toml")
+                deps = manifest["deps"]
+                @test only(deps["DataStructures"])["version"] == "0.18.0"
+                @test only(deps["StaticArrays"])["version"] == "1.9.8"
+                @test only(deps["JSON"])["version"] == "0.21.4"
+                @test only(deps["BenchmarkTools"])["version"] == "1.5.0"
+                local_a = only(deps["LocalA"])
+                local_b = only(deps["LocalB"])
+                @test local_a["path"] == "LocalA"
+                @test Set(local_a["deps"]) ==
+                      Set(["DataStructures", "JSON", "StaticArrays"])
+                @test local_b["path"] == "LocalB"
+                @test Set(local_b["deps"]) == Set(["StaticArrays"])
+                run(`$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
+
+                restored = TOML.parsefile("Project.toml")
+                @test Set(keys(restored["sources"])) == Set(["LocalA", "LocalB"])
+                @test haskey(restored["weakdeps"], "DataStructures")
+                @test !haskey(restored["deps"], "DataStructures")
+                @test !haskey(restored["deps"], "StaticArrays")
+            end
+        end
+    end
+
     @testset "split projects rebase direct path sources in both locked manifests" begin
         mktempdir() do dir
             cd(dir) do
@@ -984,13 +1099,13 @@ end
                     version = "0.1.0"
 
                     [deps]
-                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
                     [compat]
-                    JSON = "0.21"
+                    StaticArrays = "1.9.8"
                     """
                 )
-                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing JSON\nend\n")
+                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing StaticArrays\nend\n")
 
                 mkpath("src")
                 mkpath("test")
@@ -1040,10 +1155,10 @@ end
                 test_manifest = TOML.parsefile("test/Manifest.toml")
                 main_deps = main_manifest["deps"]
                 test_deps = test_manifest["deps"]
+                @test only(main_deps["StaticArrays"])["version"] == "1.9.8"
                 @test only(main_deps["JSON"])["version"] == "0.21.4"
                 @test only(main_deps["BenchmarkTools"])["version"] == "1.5.0"
                 @test only(main_deps["LocalDep"])["path"] == "LocalDep"
-                @test Set(only(main_deps["LocalDep"])["deps"]) == Set(["JSON"])
                 @test only(test_deps["LocalDep"])["path"] == "../LocalDep"
                 @test only(main_deps["RootPkg"])["path"] == "."
                 @test only(test_deps["RootPkg"])["path"] == ".."
@@ -1051,13 +1166,157 @@ end
 
                 locked = Dict(
                     name => only(test_deps[name])["version"]
-                    for name in ("BenchmarkTools", "JSON")
+                    for name in ("BenchmarkTools", "JSON", "StaticArrays")
                 )
                 run(`$(Base.julia_cmd()) --project=test -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'`)
                 after = TOML.parsefile("test/Manifest.toml")["deps"]
                 @test locked == Dict(
                     name => only(after[name])["version"] for name in keys(locked)
                 )
+            end
+        end
+    end
+
+    @testset "locked tests reject an incompatible root-owned path dependency floor" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalDep/src")
+                write(
+                    "LocalDep/Project.toml",
+                    """
+                    name = "LocalDep"
+                    uuid = "77777777-7777-7777-7777-777777777777"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [compat]
+                    JSON = "0.20"
+                    """
+                )
+                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing JSON\nend\n")
+
+                mkpath("src")
+                mkpath("test")
+                write("src/RootPkg.jl", "module RootPkg\nusing LocalDep\nend\n")
+                write("test/runtests.jl", "using Test, RootPkg\n@test true\n")
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "88888888-8888-8888-8888-888888888888"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    LocalDep = "77777777-7777-7777-7777-777777777777"
+
+                    [sources]
+                    LocalDep = {path = "LocalDep"}
+
+                    [compat]
+                    julia = "1.10"
+                    JSON = "=0.21.4"
+                    LocalDep = "0.1"
+
+                    [extras]
+                    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+                    [targets]
+                    test = ["Test"]
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`)
+                manifest = TOML.parsefile("Manifest.toml")
+                @test only(manifest["deps"]["JSON"])["version"] == "0.21.4"
+
+                output = IOBuffer()
+                process = run(
+                    pipeline(
+                        `$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`;
+                        stdout = output, stderr = output
+                    ); wait = false
+                )
+                wait(process)
+                log = String(take!(output))
+                @test !success(process)
+                @test occursin("JSON", log)
+                @test occursin("compat", lowercase(log)) || occursin("0.20", log)
+            end
+        end
+    end
+
+    @testset "direct path sources reject different compat for a promoted dependency" begin
+        mktempdir() do dir
+            cd(dir) do
+                for (name, uuid, constraint) in (
+                        ("LocalA", "44444444-4444-4444-4444-444444444444", "1.9.8"),
+                        ("LocalB", "66666666-6666-6666-6666-666666666666", "1.9.9")
+                    )
+                    mkpath("$name/src")
+                    write(
+                        "$name/Project.toml",
+                        """
+                        name = "$name"
+                        uuid = "$uuid"
+                        version = "0.1.0"
+
+                        [deps]
+                        StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+                        [compat]
+                        StaticArrays = "$constraint"
+                        """
+                    )
+                    write("$name/src/$name.jl", "module $name\nend\n")
+                end
+                mkdir("test")
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "55555555-5555-5555-5555-555555555555"
+                    version = "0.1.0"
+
+                    [deps]
+                    LocalA = "44444444-4444-4444-4444-444444444444"
+
+                    [sources]
+                    LocalA = {path = "LocalA"}
+
+                    [compat]
+                    julia = "1.10"
+                    LocalA = "0.1"
+                    """
+                )
+                write(
+                    "test/Project.toml",
+                    """
+                    [deps]
+                    LocalB = "66666666-6666-6666-6666-666666666666"
+                    RootPkg = "55555555-5555-5555-5555-555555555555"
+
+                    [sources]
+                    LocalB = {path = "../LocalB"}
+                    RootPkg = {path = ".."}
+
+                    [compat]
+                    LocalB = "0.1"
+                    """
+                )
+
+                output = IOBuffer()
+                process = run(
+                    pipeline(
+                        `$(Base.julia_cmd()) $downgrade_jl "" ".,test" "deps" "1.10"`;
+                        stdout = output, stderr = output
+                    ); wait = false
+                )
+                wait(process)
+                @test !success(process)
+                @test occursin("different compat entries", String(take!(output)))
             end
         end
     end


### PR DESCRIPTION
Ignore this PR until it has been reviewed by @ChrisRackauckas.

## Stack and review scope

This PR is stacked on #54 and must not merge before it. Its branch contains both commits because the authenticated fork account received a 403 when creating an upstream feature branch for a clean GitHub base. The follow-up review scope is only commit `1a54f43efc8e38dd0dee13170897effd844eef7c`; after #54 merges, GitHub will automatically narrow this PR's diff to that second commit.

## Summary

- include hard registry dependencies declared by direct runtime path packages in minimum-version resolution
- preserve root-owned dependency UUIDs and compat floors, including temporary promotion of a root weak dependency when a path package needs it strongly
- reject conflicting UUID or compat declarations from two direct path packages
- use a temporary merged project for non-extras path-source resolution and remove the obsolete in-place project mutation helpers
- document the deliberately limited direct-source behavior

## Why

#54 reconstructs direct path entries after merged resolution, but a dependency declared only inside the local package is still absent from the resolver input. The generated manifest can therefore omit that dependency or select no tested lower bound for it. This follow-up makes those direct hard dependencies participate in the floor resolution while leaving root-owned floors unchanged so the subsequent locked build/test can expose an incompatible root floor.

This is related to #39 and is the action-side prerequisite for locked SciML downstream environments that use local subpackages through `[sources]`.

## Deliberate limits

- only direct runtime `[sources]` entries with `path` are inspected
- nested path sources and a path package's weak dependencies are not traversed
- different compat strings are not intersected; promoted-source collisions must match exactly
- an existing root dependency keeps the root compat floor, and the locked build/test validates it against the local package

## Validation

- `julia +1.10 --startup-file=no test/runtests.jl`
  - 136/136 passed in 11m13.3s
- `julia +1 --startup-file=no test/runtests.jl` (Julia 1.12.6)
  - 136/136 passed in 14m33.3s
- `git diff --check`

The new coverage verifies same-project and split-project sources, exact promoted floors, root weakdep promotion without mutating the original project, locked package tests, incompatible root floors that must fail downstream, and cross-project promoted-compat collisions.

## Process

1. Reproduced the missing direct path-package constraint in local action fixtures and in the SciML downstream layout.
2. Kept the root project authoritative for dependencies it already declares; the locked test remains the compatibility check instead of silently raising that floor.
3. Added explicit collision errors for newly promoted dependencies and documented the non-recursive scope.
4. Ran the full suite independently on Julia 1.10 and current Julia before publishing the PR.
