### PR TITLE
Resolve recursive path-source dependency floors

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,29 @@ Cross-runtime resolution may fail; matching runtime and target version is recomm
 
 ### Local path sources
 
-For a direct runtime dependency configured with `[sources]` and `path`, the
-action includes hard registry dependencies that are declared by the local
-package but missing from the active project in the minimum-version resolution.
+For a dependency configured with `[sources]` and `path`, including one selected
+only by `[targets].test`, the action includes hard registry dependencies that
+are declared by the local package but missing from the active project in the
+minimum-version resolution. It follows active path sources recursively, so
+local monorepo dependencies remain local throughout the locked build and test.
 Dependencies already declared by the active project retain their compat floor;
 the subsequent locked build and test validate that floor against the local
-package. If two direct path packages add the same missing dependency, their UUID
-and compat strings must match or the action fails.
+package. If two path packages add the same missing dependency, their UUIDs must
+match and their compat constraints must overlap. The action resolves the
+dependency against the intersection of those constraints.
 
-This support is intentionally limited to direct path packages. It does not
-traverse nested path sources, promote their weak dependencies, or intersect
-different compat strings for an existing project dependency.
+When a local path package appears only in `[targets].test`, the action also adds
+it to `[deps]` in the checkout after resolution. This is required because
+`Pkg.test` otherwise handles it as a new sandbox dependency: older Julia
+versions reject the unregistered package, while newer versions can re-resolve
+its dependencies above their locked floors. The original `[extras]` entries,
+`[sources]` entries, and test target remain unchanged. A promoted path package
+from `[weakdeps]` is moved into `[extras]` so older Julia versions retain its
+local source in the test sandbox. `Project.toml` is left modified for the
+subsequent build and test steps.
+
+This support does not promote path-package weak dependencies or intersect
+path-package compat constraints with an existing root-owned dependency.
 
 ## Downgrade Modes
 

--- a/README.md
+++ b/README.md
@@ -130,24 +130,30 @@ only by `[targets].test`, the action includes hard registry dependencies that
 are declared by the local package but missing from the active project in the
 minimum-version resolution. It follows active path sources recursively, so
 local monorepo dependencies remain local throughout the locked build and test.
-Dependencies already declared by the active project retain their compat floor;
-the subsequent locked build and test validate that floor against the local
-package. If two path packages add the same missing dependency, their UUIDs must
-match and their compat constraints must overlap. The action resolves the
-dependency against the intersection of those constraints.
+Dependencies already declared by the active project retain their UUID and have
+their compat intersected with the local packages' constraints. If the root and
+local constraints, or constraints from two local packages, do not overlap, the
+action reports the conflict before producing a locked manifest.
 
-When a local path package appears only in `[targets].test`, the action also adds
-it to `[deps]` in the checkout after resolution. This is required because
-`Pkg.test` otherwise handles it as a new sandbox dependency: older Julia
-versions reject the unregistered package, while newer versions can re-resolve
-its dependencies above their locked floors. The original `[extras]` entries,
-`[sources]` entries, and test target remain unchanged. A promoted path package
-from `[weakdeps]` is moved into `[extras]` so older Julia versions retain its
-local source in the test sandbox. `Project.toml` is left modified for the
-subsequent build and test steps.
+When a local path package appears only in `[targets].test`, Julia 1.11 and newer
+honor its `[sources]` entry but resolve its dependency graph independently while
+constructing the `Pkg.test` sandbox. This can upgrade a dependency above the
+locked minimum even with `allow_reresolve=false`. The action therefore promotes
+the test-only path graph's hard non-local dependencies to root `[deps]` in the
+checkout. The local package itself remains a test dependency. A weak-only test
+source is added to `[extras]` because Pkg requires every `[sources]` entry to
+appear in `[deps]` or `[extras]`; its `[weakdeps]` entry remains intact.
 
-This support does not promote path-package weak dependencies or intersect
-path-package compat constraints with an existing root-owned dependency.
+Julia 1.10 and earlier do not honor `[sources]` while constructing the
+`Pkg.test` sandbox. On those versions, the action also promotes test-only path
+packages to `[deps]` in the checkout so the locked test can use them. Weak-only
+test packages are also removed from `[weakdeps]` as part of that compatibility
+fallback.
+
+These promotions intentionally leave `Project.toml` modified for subsequent
+locked build and test steps.
+
+This support does not promote path-package weak dependencies.
 
 ## Downgrade Modes
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ For Julia `>= 1.12`, using `julia-actions/julia-runtest` with
 When possible, run the action on the same Julia version that you pass as `julia_version`.
 Cross-runtime resolution may fail; matching runtime and target version is recommended and the default for `julia_version`.
 
+### Local path sources
+
+For a direct runtime dependency configured with `[sources]` and `path`, the
+action includes hard registry dependencies that are declared by the local
+package but missing from the active project in the minimum-version resolution.
+Dependencies already declared by the active project retain their compat floor;
+the subsequent locked build and test validate that floor against the local
+package. If two direct path packages add the same missing dependency, their UUID
+and compat strings must match or the action fails.
+
+This support is intentionally limited to direct path packages. It does not
+traverse nested path sources, promote their weak dependencies, or intersect
+different compat strings for an existing project dependency.
+
 ## Downgrade Modes
 
 - **`deps`**: Minimize only your direct dependencies (recommended for most packages)

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -139,9 +139,10 @@ function get_source_packages(project_file::String)
     return source_pkgs
 end
 
-struct DirectRuntimePathSource
+struct DirectPathSource
     name::String
     project::Dict{String, Any}
+    project_file::String
 end
 
 function find_project_file(dir::AbstractString)
@@ -153,61 +154,197 @@ function find_project_file(dir::AbstractString)
 end
 
 """
-    collect_direct_runtime_path_sources(project_file) -> Vector{DirectRuntimePathSource}
+    active_project_dependencies(project; include_test_target = false)
 
-Collect direct local path packages that occur in both runtime `[deps]` and
-`[sources]` in `project_file`. Nested path sources are intentionally not
-traversed.
+Return the dependencies active in the project environment. When
+`include_test_target` is true, this also includes extras or weak dependencies
+selected by `[targets].test`.
 """
-function collect_direct_runtime_path_sources(project_file::String)
-    root_file = abspath(project_file)
-    root_dir = dirname(root_file)
-    root_project = TOML.parsefile(root_file)
-    deps = get(root_project, "deps", Dict{String, Any}())
-    sources = get(root_project, "sources", Dict{String, Any}())
-    result = DirectRuntimePathSource[]
+function active_project_dependencies(project; include_test_target = false)
+    deps = Dict{String, Any}(get(project, "deps", Dict{String, Any}()))
+    include_test_target || return deps
 
-    for name in sort!(collect(keys(sources)))
-        haskey(deps, name) || continue
-        source = sources[name]
-        source isa AbstractDict || continue
-        haskey(source, "path") || continue
+    extras = get(project, "extras", Dict{String, Any}())
+    weakdeps = get(project, "weakdeps", Dict{String, Any}())
+    test_target = get(get(project, "targets", Dict{String, Any}()), "test", String[])
+    for name in test_target
+        haskey(deps, name) && continue
+        if haskey(extras, name)
+            deps[name] = extras[name]
+        elseif haskey(weakdeps, name)
+            deps[name] = weakdeps[name]
+        end
+    end
+    return deps
+end
 
-        source_dir = normpath(abspath(joinpath(root_dir, source["path"])))
-        source_file = find_project_file(source_dir)
-        source_file === nothing &&
-            error("Path source $name from $root_file has no project file at $source_dir")
-        source_project = TOML.parsefile(source_file)
-        declared_name = get(source_project, "name", name)
-        declared_name == name ||
-            error("Path source $name from $root_file declares package name $declared_name")
-        declared_uuid = get(source_project, "uuid", nothing)
-        declared_uuid == deps[name] || error(
-            "Path source $name from $root_file has uuid $declared_uuid, expected $(deps[name])"
-        )
-        push!(result, DirectRuntimePathSource(name, source_project))
+"""
+    promote_test_target_path_sources!(project_file) -> Vector{String}
+
+Promote local path packages used only by `[targets].test` into `[deps]` in the
+resolved checkout. `Pkg.test` otherwise treats them as new sandbox dependencies
+and either rejects them as unregistered or re-resolves their dependency graph
+away from the locked minimum versions.
+"""
+function promote_test_target_path_sources!(project_file::String)
+    project = TOML.parsefile(project_file)
+    deps = get!(project, "deps", Dict{String, Any}())
+    extras = get!(project, "extras", Dict{String, Any}())
+    weakdeps = get(project, "weakdeps", Dict{String, Any}())
+    sources = get(project, "sources", Dict{String, Any}())
+    test_target = get(get(project, "targets", Dict{String, Any}()), "test", String[])
+    promoted = String[]
+
+    for name in test_target
+        haskey(deps, name) && continue
+        source = get(sources, name, nothing)
+        (source isa AbstractDict && haskey(source, "path")) || continue
+
+        uuid = get(extras, name, nothing)
+        weak_uuid = get(weakdeps, name, nothing)
+        if uuid === nothing
+            uuid = weak_uuid
+            uuid === nothing && continue
+            extras[name] = uuid
+        elseif weak_uuid !== nothing && weak_uuid != uuid
+            error(
+                "Test-target path source $name has uuid $uuid in [extras], " *
+                    "but $weak_uuid in [weakdeps]"
+            )
+        end
+        if weak_uuid !== nothing
+            delete!(weakdeps, name)
+            isempty(weakdeps) && delete!(project, "weakdeps")
+        end
+        deps[name] = uuid
+        push!(promoted, name)
     end
 
+    isempty(promoted) && return promoted
+    open(project_file, "w") do io
+        TOML.print(io, project)
+    end
+    @info "Promoted test-target path sources into runtime dependencies for locked Pkg.test" promoted
+    return promoted
+end
+
+"""
+    collect_path_sources(project_file; include_test_target = true) -> Vector{DirectPathSource}
+
+Collect local path packages that occur in `[sources]` and are active as runtime
+dependencies or, for the root project, in `[targets].test`. Path sources of
+those packages are followed recursively using runtime dependencies only.
+"""
+function collect_path_sources(project_file::String; include_test_target = true)
+    result = DirectPathSource[]
+    seen = Dict{String, DirectPathSource}()
+
+    function visit(parent_file::String; include_test_target = false)
+        parent_file = abspath(parent_file)
+        parent_dir = dirname(parent_file)
+        parent_project = TOML.parsefile(parent_file)
+        deps = active_project_dependencies(parent_project; include_test_target)
+        sources = get(parent_project, "sources", Dict{String, Any}())
+
+        for name in sort!(collect(keys(sources)))
+            haskey(deps, name) || continue
+            source = sources[name]
+            source isa AbstractDict || continue
+            haskey(source, "path") || continue
+
+            source_dir = normpath(abspath(joinpath(parent_dir, source["path"])))
+            source_file = find_project_file(source_dir)
+            source_file === nothing && error(
+                "Path source $name from $parent_file has no project file at $source_dir"
+            )
+            source_file = abspath(source_file)
+            source_project = TOML.parsefile(source_file)
+            declared_name = get(source_project, "name", name)
+            declared_name == name || error(
+                "Path source $name from $parent_file declares package name $declared_name"
+            )
+            declared_uuid = get(source_project, "uuid", nothing)
+            declared_uuid == deps[name] || error(
+                "Path source $name from $parent_file has uuid $declared_uuid, " *
+                    "expected $(deps[name])"
+            )
+
+            if haskey(seen, name)
+                previous = seen[name]
+                get(previous.project, "uuid", nothing) == declared_uuid || error(
+                    "Path source $name resolves to different uuids"
+                )
+                previous.project_file == source_file || error(
+                    "Path source $name resolves to both $(previous.project_file) and $source_file"
+                )
+                continue
+            end
+
+            path_source = DirectPathSource(name, source_project, source_file)
+            seen[name] = path_source
+            push!(result, path_source)
+            visit(source_file)
+        end
+        return
+    end
+
+    visit(project_file; include_test_target)
     return result
+end
+
+function compat_constraint_string(spec)
+    raw = string(spec)
+    if startswith(raw, "[") && endswith(raw, "]")
+        raw = raw[2:(end - 1)]
+    end
+
+    ranges = map(split(raw, ", ")) do range
+        if (m = match(r"^([0-9]+(?:\.[0-9]+){0,2})-\*$", range)) !== nothing
+            return ">=" * m.captures[1]
+        elseif (
+                m = match(
+                    r"^([0-9]+(?:\.[0-9]+){0,2})-([0-9]+(?:\.[0-9]+){0,2})$",
+                    range
+                )
+            ) !== nothing
+            return m.captures[1] * " - " * m.captures[2]
+        elseif occursin(r"^[1-9][0-9]*\.[0-9]+$", range)
+            return "~" * range
+        elseif occursin(r"^[0-9]+\.[0-9]+\.[0-9]+$", range)
+            return "=" * range
+        end
+        return range
+    end
+    constraint = join(ranges, ", ")
+    Pkg.Versions.semver_spec(constraint) == spec || error(
+        "Could not serialize intersected compat constraint $spec"
+    )
+    return constraint
+end
+
+function intersect_compat_constraints(left::String, right::String)
+    result = intersect(Pkg.Versions.semver_spec(left), Pkg.Versions.semver_spec(right))
+    return isempty(result) ? nothing : compat_constraint_string(result)
 end
 
 """
     add_direct_path_source_dependencies!(merged, project_files)
 
 Add hard registry dependencies that are missing from `merged` but required by a
-direct runtime path source in `project_files`. Dependencies already owned by the
-root project keep the root UUID and compat unchanged. When two path sources add
-the same missing dependency, their UUIDs and any compat strings must agree.
+path source active at runtime or in `[targets].test`. Dependencies
+already owned by the root project keep the root UUID and compat unchanged. When
+two path sources add the same missing dependency, their UUIDs must agree and
+their compat constraints are intersected.
 
-This intentionally does not traverse nested path sources, include dependencies
-from a path package's `[weakdeps]`, or intersect differing compat specifications.
-The locked package build and tests remain responsible for validating root-owned
-dependency versions against the path package.
+This does not include dependencies from a path package's `[weakdeps]` or
+intersect path-package compat constraints with an existing root-owned
+dependency. The locked package build and tests remain responsible for
+validating root-owned dependency versions against the path package.
 """
 function add_direct_path_source_dependencies!(merged, project_files::Vector{String})
     path_sources = reduce(
-        vcat, collect_direct_runtime_path_sources.(project_files);
-        init = DirectRuntimePathSource[]
+        vcat, collect_path_sources.(project_files);
+        init = DirectPathSource[]
     )
     isempty(path_sources) && return
 
@@ -231,7 +368,7 @@ function add_direct_path_source_dependencies!(merged, project_files::Vector{Stri
             if name in root_owned
                 deps[name] == uuid || error(
                     "Root dependency $name has uuid $(deps[name]), but path source " *
-                    "$(source.name) requires $uuid"
+                        "$(source.name) requires $uuid"
                 )
                 continue
             end
@@ -239,7 +376,7 @@ function add_direct_path_source_dependencies!(merged, project_files::Vector{Stri
             if haskey(weakdeps, name)
                 weakdeps[name] == uuid || error(
                     "Root weak dependency $name has uuid $(weakdeps[name]), but path " *
-                    "source $(source.name) requires $uuid"
+                        "source $(source.name) requires $uuid"
                 )
                 deps[name] = uuid
                 delete!(weakdeps, name)
@@ -253,14 +390,16 @@ function add_direct_path_source_dependencies!(merged, project_files::Vector{Stri
             if haskey(promoted_by, name)
                 deps[name] == uuid || error(
                     "Path sources $(promoted_by[name]) and $(source.name) require " *
-                    "$name with different uuids $(deps[name]) and $uuid"
+                        "$name with different uuids $(deps[name]) and $uuid"
                 )
-                if constraint !== nothing && haskey(compat, name) &&
-                        compat[name] != constraint
-                    error(
+                if constraint !== nothing && haskey(compat, name)
+                    existing = compat[name]
+                    intersection = intersect_compat_constraints(existing, constraint)
+                    intersection === nothing && error(
                         "Path sources $(promoted_by[name]) and $(source.name) require " *
-                        "$name with different compat entries $(compat[name]) and $constraint"
+                            "$name with disjoint compat entries $existing and $constraint"
                     )
+                    compat[name] = intersection
                 elseif constraint !== nothing
                     compat[name] = constraint
                 end
@@ -273,7 +412,7 @@ function add_direct_path_source_dependencies!(merged, project_files::Vector{Stri
                 if haskey(compat, name) && compat[name] != constraint
                     error(
                         "Project compat for promoted dependency $name is $(compat[name]), " *
-                        "but path source $(source.name) requires $constraint"
+                            "but path source $(source.name) requires $constraint"
                     )
                 end
                 compat[name] = constraint
@@ -616,9 +755,9 @@ in Project.toml but absent from Manifest.toml" (see #3021). Each such package is
 written back as a path dependency pointing at the same location given in
 `[sources]`, mirroring `add_main_package_to_manifest`.
 
-Note: only packages that are themselves in `[deps]` need to be in this manifest;
-packages sourced solely for a test target are not part of the resolved
-environment. Nested path sources are not followed.
+Packages sourced solely for `[targets].test` are included when this manifest was
+produced from the merged test environment. Active nested path sources are
+included recursively.
 
 If the resolver already emitted a registry entry for a source package (which
 happens whenever another resolved package depends on it), that entry is removed
@@ -628,43 +767,28 @@ dependency on ... is ambiguous". The path source must win, since that is the
 whole point of the `[sources]` override.
 """
 function add_source_packages_to_manifest(
-        manifest_file::String, project_file::String, manifest_dir::AbstractString, source_pkgs)
+        manifest_file::String, project_file::String, manifest_dir::AbstractString, source_pkgs;
+        include_test_target = false
+    )
     isempty(source_pkgs) && return
     if !isfile(manifest_file)
         @warn "Manifest file not found: $manifest_file"
         return
     end
 
-    project = TOML.parsefile(project_file)
-    sources = get(project, "sources", Dict())
-    deps = get(project, "deps", Dict())
-    project_dir = dirname(abspath(project_file))
+    path_sources = collect_path_sources(project_file; include_test_target)
+    isempty(path_sources) && return
     manifest_dir = abspath(manifest_dir)
 
     entry_lines = String[]
     added_pkgs = String[]
-    for pkg in source_pkgs
-        # Only packages that are part of this environment's [deps] belong in its
-        # manifest; sources used only by a test target are not.
-        haskey(deps, pkg) || continue
-        src = get(sources, pkg, nothing)
-        (src isa Dict && haskey(src, "path")) || continue
-
-        source_path = normpath(joinpath(project_dir, src["path"]))
+    for source in path_sources
+        pkg = source.name
+        source_path = dirname(source.project_file)
         pkg_path = relpath(source_path, manifest_dir)
-        candidates = [joinpath(source_path, "Project.toml"),
-                      joinpath(source_path, "JuliaProject.toml")]
-        filter!(isfile, candidates)
-        uuid = get(deps, pkg, nothing)
-        version = nothing
-        hard_deps = String[]
-        if !isempty(candidates)
-            pkg_project = TOML.parsefile(first(candidates))
-            uuid = get(pkg_project, "uuid", uuid)
-            version = get(pkg_project, "version", nothing)
-            append!(hard_deps, keys(get(pkg_project, "deps", Dict{String, Any}())))
-            sort!(hard_deps)
-        end
+        uuid = get(source.project, "uuid", nothing)
+        version = get(source.project, "version", nothing)
+        hard_deps = sort!(collect(keys(get(source.project, "deps", Dict{String, Any}()))))
         if uuid === nothing
             @warn "Could not determine uuid for source package $pkg, skipping manifest entry"
             continue
@@ -724,9 +848,10 @@ function resolve_directory(
     manifest_file = joinpath(dir, "Manifest.toml")
     project = TOML.parsefile(project_file)
 
-    # Check for old-style test dependencies (extras)
-    if haskey(project, "extras") && haskey(project, "targets") && haskey(project["targets"], "test")
-        @info "Project $dir has [extras] and [targets].test, using merged resolution"
+    has_test_target = haskey(project, "targets") && haskey(project["targets"], "test")
+    has_test_dependencies = haskey(project, "extras") || haskey(project, "weakdeps")
+    if has_test_target && has_test_dependencies
+        @info "Project $dir has test dependencies and [targets].test, using merged resolution"
         merged_dir = mktempdir()
         source_pkgs = create_merged_project(project_file, project_file, merged_dir; no_promote)
 
@@ -743,8 +868,12 @@ function resolve_directory(
                 # Add the main package itself and other source packages back to the manifest
                 add_main_package_to_manifest(manifest_file, project_file; path = ".")
                 if !isempty(source_pkgs)
-                    add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
+                    add_source_packages_to_manifest(
+                        manifest_file, project_file, dir, source_pkgs;
+                        include_test_target = true
+                    )
                 end
+                promote_test_target_path_sources!(project_file)
                 set_manifest_project_hash(manifest_file, project_file)
             end
         finally
@@ -1049,12 +1178,17 @@ if do_merge
                 (main_manifest, main_dir), (test_manifest, test_dir)
             )
             add_source_packages_to_manifest(
-                manifest, main_project_file, manifest_dir, main_source_pkgs
+                manifest, main_project_file, manifest_dir, main_source_pkgs;
+                include_test_target = true
             )
             add_source_packages_to_manifest(
-                manifest, test_project_file, manifest_dir, test_source_pkgs
+                manifest, test_project_file, manifest_dir, test_source_pkgs;
+                include_test_target = true
             )
         end
+
+        promote_test_target_path_sources!(main_project_file)
+        promote_test_target_path_sources!(test_project_file)
 
         # Ensure each manifest has the project hash corresponding to the project
         # that will consume it (main root and test environment respectively).

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -535,7 +535,7 @@ function set_manifest_project_hash(manifest_file::String, project_file::String)
 end
 
 """
-    add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
+    add_source_packages_to_manifest(manifest_file, project_file, manifest_dir, source_pkgs)
 
 Re-add local path-sourced packages to `manifest_file` after resolution.
 
@@ -560,7 +560,7 @@ dependency on ... is ambiguous". The path source must win, since that is the
 whole point of the `[sources]` override.
 """
 function add_source_packages_to_manifest(
-        manifest_file::String, project_file::String, dir::AbstractString, source_pkgs)
+        manifest_file::String, project_file::String, manifest_dir::AbstractString, source_pkgs)
     isempty(source_pkgs) && return
     if !isfile(manifest_file)
         @warn "Manifest file not found: $manifest_file"
@@ -570,6 +570,8 @@ function add_source_packages_to_manifest(
     project = TOML.parsefile(project_file)
     sources = get(project, "sources", Dict())
     deps = get(project, "deps", Dict())
+    project_dir = dirname(abspath(project_file))
+    manifest_dir = abspath(manifest_dir)
 
     entry_lines = String[]
     added_pkgs = String[]
@@ -580,16 +582,20 @@ function add_source_packages_to_manifest(
         src = get(sources, pkg, nothing)
         (src isa Dict && haskey(src, "path")) || continue
 
-        pkg_path = src["path"]
-        candidates = [joinpath(dir, pkg_path, "Project.toml"),
-                      joinpath(dir, pkg_path, "JuliaProject.toml")]
+        source_path = normpath(joinpath(project_dir, src["path"]))
+        pkg_path = relpath(source_path, manifest_dir)
+        candidates = [joinpath(source_path, "Project.toml"),
+                      joinpath(source_path, "JuliaProject.toml")]
         filter!(isfile, candidates)
         uuid = get(deps, pkg, nothing)
         version = nothing
+        hard_deps = String[]
         if !isempty(candidates)
             pkg_project = TOML.parsefile(first(candidates))
             uuid = get(pkg_project, "uuid", uuid)
             version = get(pkg_project, "version", nothing)
+            append!(hard_deps, keys(get(pkg_project, "deps", Dict{String, Any}())))
+            sort!(hard_deps)
         end
         if uuid === nothing
             @warn "Could not determine uuid for source package $pkg, skipping manifest entry"
@@ -597,6 +603,7 @@ function add_source_packages_to_manifest(
         end
 
         push!(entry_lines, "[[deps.$pkg]]")
+        isempty(hard_deps) || push!(entry_lines, "deps = $(repr(hard_deps))")
         push!(entry_lines, "path = \"$pkg_path\"")
         push!(entry_lines, "uuid = \"$uuid\"")
         version !== nothing && push!(entry_lines, "version = \"$version\"")
@@ -966,6 +973,18 @@ if do_merge
         # This is needed for workspace projects where the test project depends on the main package
         add_main_package_to_manifest(main_manifest, main_project_file; path = ".")
         add_main_package_to_manifest(test_manifest, main_project_file; path = "..")
+        main_source_pkgs = get_source_packages(main_project_file)
+        test_source_pkgs = get_source_packages(test_project_file)
+        for (manifest, manifest_dir) in (
+                (main_manifest, main_dir), (test_manifest, test_dir)
+            )
+            add_source_packages_to_manifest(
+                manifest, main_project_file, manifest_dir, main_source_pkgs
+            )
+            add_source_packages_to_manifest(
+                manifest, test_project_file, manifest_dir, test_source_pkgs
+            )
+        end
 
         # Ensure each manifest has the project hash corresponding to the project
         # that will consume it (main root and test environment respectively).

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -179,21 +179,19 @@ function active_project_dependencies(project; include_test_target = false)
 end
 
 """
-    promote_test_target_path_sources!(project_file) -> Vector{String}
+    test_target_path_sources(project_file) -> Vector{String}
 
-Promote local path packages used only by `[targets].test` into `[deps]` in the
-resolved checkout. `Pkg.test` otherwise treats them as new sandbox dependencies
-and either rejects them as unregistered or re-resolves their dependency graph
-away from the locked minimum versions.
+Return local path packages selected by `[targets].test` but absent from runtime
+`[deps]`.
 """
-function promote_test_target_path_sources!(project_file::String)
+function test_target_path_sources(project_file::String)
     project = TOML.parsefile(project_file)
-    deps = get!(project, "deps", Dict{String, Any}())
-    extras = get!(project, "extras", Dict{String, Any}())
+    deps = get(project, "deps", Dict{String, Any}())
+    extras = get(project, "extras", Dict{String, Any}())
     weakdeps = get(project, "weakdeps", Dict{String, Any}())
     sources = get(project, "sources", Dict{String, Any}())
     test_target = get(get(project, "targets", Dict{String, Any}()), "test", String[])
-    promoted = String[]
+    result = String[]
 
     for name in test_target
         haskey(deps, name) && continue
@@ -205,27 +203,101 @@ function promote_test_target_path_sources!(project_file::String)
         if uuid === nothing
             uuid = weak_uuid
             uuid === nothing && continue
-            extras[name] = uuid
         elseif weak_uuid !== nothing && weak_uuid != uuid
             error(
                 "Test-target path source $name has uuid $uuid in [extras], " *
                     "but $weak_uuid in [weakdeps]"
             )
         end
-        if weak_uuid !== nothing
-            delete!(weakdeps, name)
-            isempty(weakdeps) && delete!(project, "weakdeps")
-        end
-        deps[name] = uuid
-        push!(promoted, name)
+        push!(result, name)
     end
 
-    isempty(promoted) && return promoted
+    return result
+end
+
+"""
+    prepare_test_target_path_sources!(project_file; registry_deps) -> Vector{String}
+
+Prepare test-only path sources for a locked `Pkg.test` and return their names.
+Weak-only sources are also added to `[extras]`, as Pkg requires every
+`[sources]` entry there or in `[deps]`. On Julia 1.11 and newer, hard registry
+dependencies used only through these sources are promoted to runtime `[deps]`
+so `Pkg.test` preserves their resolved versions. Julia 1.10 and earlier instead
+require the path sources themselves in runtime `[deps]` because their test
+sandbox does not honor `[sources]`.
+"""
+function prepare_test_target_path_sources!(
+        project_file::String; registry_deps = Dict{String, Any}())
+    names = test_target_path_sources(project_file)
+
+    project = TOML.parsefile(project_file)
+    deps = VERSION < v"1.11" || !isempty(registry_deps) ?
+           get!(project, "deps", Dict{String, Any}()) :
+           get(project, "deps", Dict{String, Any}())
+    extras = get!(project, "extras", Dict{String, Any}())
+    weakdeps = get(project, "weakdeps", Dict{String, Any}())
+    changed = false
+    anchored = String[]
+    added_extras = String[]
+
+    if VERSION >= v"1.11"
+        for name in sort!(collect(keys(registry_deps)))
+            uuid = registry_deps[name]
+            for (section, entries) in (("[deps]", deps), ("[extras]", extras),
+                    ("[weakdeps]", weakdeps))
+                haskey(entries, name) || continue
+                entries[name] == uuid || error(
+                    "Test-only path-source dependency $name has uuid $uuid, " *
+                        "but $(entries[name]) in $section"
+                )
+            end
+
+            if haskey(weakdeps, name)
+                delete!(weakdeps, name)
+                isempty(weakdeps) && delete!(project, "weakdeps")
+                changed = true
+            end
+            if !haskey(deps, name)
+                deps[name] = uuid
+                changed = true
+                push!(anchored, name)
+            end
+        end
+    end
+
+    for name in names
+        uuid = get(extras, name, nothing)
+        weak_uuid = get(weakdeps, name, nothing)
+        if uuid === nothing
+            uuid = weak_uuid
+            extras[name] = uuid
+            changed = true
+            push!(added_extras, name)
+        end
+        if VERSION < v"1.11"
+            if weak_uuid !== nothing
+                delete!(weakdeps, name)
+                isempty(weakdeps) && delete!(project, "weakdeps")
+            end
+            deps[name] = uuid
+            changed = true
+        end
+    end
+
+    changed || return names
     open(project_file, "w") do io
         TOML.print(io, project)
     end
-    @info "Promoted test-target path sources into runtime dependencies for locked Pkg.test" promoted
-    return promoted
+    if !isempty(anchored)
+        @info "Promoted test-only path-source dependencies for locked Pkg.test" anchored
+    end
+    if !isempty(added_extras)
+        @info "Added weak-only test-target path sources to [extras] for Pkg validation" added_extras
+    end
+    if VERSION < v"1.11" && !isempty(names)
+        @info "Promoted test-target path sources for Julia $(VERSION.major).$(VERSION.minor) Pkg.test compatibility" names
+    end
+    return names
 end
 
 """
@@ -292,6 +364,50 @@ function collect_path_sources(project_file::String; include_test_target = true)
     return result
 end
 
+"""
+    test_only_path_source_dependencies(project_file; no_promote) -> Dict{String, Any}
+
+Return hard non-local dependencies introduced by path sources that are active
+only through `[targets].test`. Julia 1.11 and newer must see these as root
+dependencies or `Pkg.test` resolves that test-only graph independently of the
+locked manifest.
+"""
+function test_only_path_source_dependencies(
+        project_file::String; no_promote = String[])
+    all_sources = collect_path_sources(project_file; include_test_target = true)
+    runtime_source_names = Set(
+        source.name for source in
+        collect_path_sources(project_file; include_test_target = false)
+    )
+    local_source_names = Set(source.name for source in all_sources)
+    result = Dict{String, Any}()
+    owners = Dict{String, String}()
+
+    for source in all_sources
+        source.name in runtime_source_names && continue
+        for name in sort!(collect(keys(get(source.project, "deps", Dict{String, Any}()))))
+            name in local_source_names && continue
+            name in no_promote && continue
+            uuid = source.project["deps"][name]
+            if haskey(result, name) && result[name] != uuid
+                error(
+                    "Test-only path sources $(owners[name]) and $(source.name) require " *
+                        "$name with different uuids $(result[name]) and $uuid"
+                )
+            end
+            result[name] = uuid
+            owners[name] = source.name
+        end
+    end
+    return result
+end
+
+function parse_compat_constraint(constraint)
+    # Pkg exposes no public top-level parser for Project.toml's compat grammar.
+    # Keep the internal access isolated here instead of duplicating that grammar.
+    return Pkg.Versions.semver_spec(constraint)
+end
+
 function compat_constraint_string(spec)
     raw = string(spec)
     if startswith(raw, "[") && endswith(raw, "]")
@@ -316,15 +432,31 @@ function compat_constraint_string(spec)
         return range
     end
     constraint = join(ranges, ", ")
-    Pkg.Versions.semver_spec(constraint) == spec || error(
+    parse_compat_constraint(constraint) == spec || error(
         "Could not serialize intersected compat constraint $spec"
     )
     return constraint
 end
 
 function intersect_compat_constraints(left::String, right::String)
-    result = intersect(Pkg.Versions.semver_spec(left), Pkg.Versions.semver_spec(right))
+    result = intersect(parse_compat_constraint(left), parse_compat_constraint(right))
     return isempty(result) ? nothing : compat_constraint_string(result)
+end
+
+function merge_compat_constraint!(compat, name, constraint, owners)
+    constraint === nothing && return
+    if !haskey(compat, name)
+        compat[name] = constraint
+        return
+    end
+
+    existing = compat[name]
+    intersection = intersect_compat_constraints(existing, constraint)
+    intersection === nothing && error(
+        "$owners require $name with disjoint compat entries $existing and $constraint"
+    )
+    compat[name] = intersection
+    return
 end
 
 """
@@ -332,14 +464,12 @@ end
 
 Add hard registry dependencies that are missing from `merged` but required by a
 path source active at runtime or in `[targets].test`. Dependencies
-already owned by the root project keep the root UUID and compat unchanged. When
-two path sources add the same missing dependency, their UUIDs must agree and
-their compat constraints are intersected.
+already owned by the root project keep the root UUID, and their compat is
+intersected with each path source's constraint. When two path sources add the
+same missing dependency, their UUIDs must agree and their compat constraints are
+intersected.
 
-This does not include dependencies from a path package's `[weakdeps]` or
-intersect path-package compat constraints with an existing root-owned
-dependency. The locked package build and tests remain responsible for
-validating root-owned dependency versions against the path package.
+This does not include dependencies from a path package's `[weakdeps]`.
 """
 function add_direct_path_source_dependencies!(merged, project_files::Vector{String})
     path_sources = reduce(
@@ -360,6 +490,7 @@ function add_direct_path_source_dependencies!(merged, project_files::Vector{Stri
         source_compat = get(source.project, "compat", Dict{String, Any}())
         for name in sort!(collect(keys(source_deps)))
             uuid = source_deps[name]
+            constraint = get(source_compat, name, nothing)
             if name in local_source_names
                 @info "Leaving direct path dependency $name local while reading $(source.name)"
                 continue
@@ -369,6 +500,9 @@ function add_direct_path_source_dependencies!(merged, project_files::Vector{Stri
                 deps[name] == uuid || error(
                     "Root dependency $name has uuid $(deps[name]), but path source " *
                         "$(source.name) requires $uuid"
+                )
+                merge_compat_constraint!(
+                    compat, name, constraint, "Root project and path source $(source.name)"
                 )
                 continue
             end
@@ -383,26 +517,21 @@ function add_direct_path_source_dependencies!(merged, project_files::Vector{Stri
                 isempty(weakdeps) && delete!(merged, "weakdeps")
                 push!(root_owned, name)
                 @info "Promoting root weak dependency required by $(source.name): $name"
+                merge_compat_constraint!(
+                    compat, name, constraint, "Root project and path source $(source.name)"
+                )
                 continue
             end
 
-            constraint = get(source_compat, name, nothing)
             if haskey(promoted_by, name)
                 deps[name] == uuid || error(
                     "Path sources $(promoted_by[name]) and $(source.name) require " *
                         "$name with different uuids $(deps[name]) and $uuid"
                 )
-                if constraint !== nothing && haskey(compat, name)
-                    existing = compat[name]
-                    intersection = intersect_compat_constraints(existing, constraint)
-                    intersection === nothing && error(
-                        "Path sources $(promoted_by[name]) and $(source.name) require " *
-                            "$name with disjoint compat entries $existing and $constraint"
-                    )
-                    compat[name] = intersection
-                elseif constraint !== nothing
-                    compat[name] = constraint
-                end
+                merge_compat_constraint!(
+                    compat, name, constraint,
+                    "Path sources $(promoted_by[name]) and $(source.name)"
+                )
                 continue
             end
 
@@ -430,7 +559,7 @@ Create a merged Project.toml that combines dependencies from both the main
 project and test project. This ensures that when tests run (which combine
 both environments), the resolved versions are compatible.
 
-Returns a Set of source packages that were excluded from the merge.
+Returns the source packages excluded from the merge.
 """
 function create_merged_project(main_project_file::String, test_project_file::String, merged_dir::String;
         no_promote = String[])
@@ -679,7 +808,8 @@ sourced locally, not from the registry. The replacement entry retains the
 package's dependency, weak-dependency, and extension metadata so Pkg can load
 extensions without refreshing the locked manifest.
 """
-function add_main_package_to_manifest(manifest_file::String, main_project_file::String; path::String = ".")
+function add_main_package_to_manifest(
+        manifest_file::String, main_project_file::String; path::String = ".")
     if !isfile(manifest_file)
         @warn "Manifest file not found: $manifest_file"
         return
@@ -835,7 +965,8 @@ function resolve_directory(
     if has_test_target && has_test_dependencies
         @info "Project $dir has test dependencies and [targets].test, using merged resolution"
         merged_dir = mktempdir()
-        source_pkgs = create_merged_project(project_file, project_file, merged_dir; no_promote)
+        source_pkgs = create_merged_project(
+            project_file, project_file, merged_dir; no_promote)
 
         try
             @info "Running resolver on merged project (extras) for $dir with --min=@$resolver_mode"
@@ -847,11 +978,13 @@ function resolve_directory(
             if isfile(merged_manifest)
                 cp(merged_manifest, manifest_file; force = true)
 
-                # Promote path-backed test dependencies before recording the main
-                # package so its manifest dependency list matches the final project.
-                promote_test_target_path_sources!(project_file)
-
                 # Add the main package itself and other source packages back to the manifest
+                prepare_test_target_path_sources!(
+                    project_file;
+                    registry_deps = test_only_path_source_dependencies(
+                        project_file; no_promote
+                    )
+                )
                 add_main_package_to_manifest(manifest_file, project_file; path = ".")
                 if !isempty(source_pkgs)
                     add_source_packages_to_manifest(
@@ -1135,7 +1268,8 @@ if do_merge
 
     # Create merged project in temp directory
     merged_dir = mktempdir()
-    source_pkgs = create_merged_project(main_project_file, test_project_file, merged_dir; no_promote)
+    source_pkgs = create_merged_project(
+        main_project_file, test_project_file, merged_dir; no_promote)
 
     # Run resolver on merged project
     @info "Running resolver on merged project with --min=@$resolver_mode"
@@ -1153,15 +1287,18 @@ if do_merge
         cp(merged_manifest, test_manifest; force = true)
         @info "Copied merged manifest to $test_manifest"
 
-        # Promote path-backed test dependencies before recording the main
-        # package so its manifest dependency list matches the final project.
-        promote_test_target_path_sources!(main_project_file)
-        promote_test_target_path_sources!(test_project_file)
-
-        # Add the main package itself to the manifest as a path dependency
-        # This is needed for workspace projects where the test project depends on the main package
-        add_main_package_to_manifest(main_manifest, main_project_file; path = ".")
-        add_main_package_to_manifest(test_manifest, main_project_file; path = "..")
+        prepare_test_target_path_sources!(
+            main_project_file;
+            registry_deps = test_only_path_source_dependencies(
+                main_project_file; no_promote
+            )
+        )
+        prepare_test_target_path_sources!(
+            test_project_file;
+            registry_deps = test_only_path_source_dependencies(
+                test_project_file; no_promote
+            )
+        )
         main_source_pkgs = get_source_packages(main_project_file)
         test_source_pkgs = get_source_packages(test_project_file)
         for (manifest, manifest_dir) in (
@@ -1176,6 +1313,10 @@ if do_merge
                 include_test_target = true
             )
         end
+        # Add this last because test/Project.toml commonly lists the main
+        # package as a path source, which would otherwise replace this entry.
+        add_main_package_to_manifest(main_manifest, main_project_file; path = ".")
+        add_main_package_to_manifest(test_manifest, main_project_file; path = "..")
         # Ensure each manifest has the project hash corresponding to the project
         # that will consume it (main root and test environment respectively).
         set_manifest_project_hash(main_manifest, main_project_file)

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -630,6 +630,35 @@ function remove_manifest_entries_by_uuid!(manifest::AbstractDict, uuid::Abstract
     return removed
 end
 
+function path_manifest_entry(project, path)
+    entry = Dict{String, Any}(
+        "path" => path,
+        "uuid" => project["uuid"],
+    )
+
+    hard_deps = sort!(collect(keys(get(project, "deps", Dict{String, Any}()))))
+    isempty(hard_deps) || (entry["deps"] = hard_deps)
+
+    for section in ("extensions", "weakdeps")
+        metadata = get(project, section, nothing)
+        metadata isa AbstractDict && !isempty(metadata) &&
+            (entry[section] = deepcopy(metadata))
+    end
+
+    version = get(project, "version", nothing)
+    version === nothing || (entry["version"] = version)
+    return entry
+end
+
+function replace_manifest_path_entry!(manifest, pkg_name, project, path)
+    uuid = project["uuid"]
+    removed = remove_manifest_entries_by_uuid!(manifest, uuid)
+    deps = get(manifest, "deps", manifest)
+    haskey(deps, pkg_name) && pkg_name ∉ removed && push!(removed, pkg_name)
+    deps[pkg_name] = [path_manifest_entry(project, path)]
+    return removed
+end
+
 """
     add_main_package_to_manifest(manifest_file, main_project_file)
 
@@ -646,7 +675,9 @@ the main package from the registry, so blindly appending the path stanza would
 leave two `[[deps.<MainPkg>]]` entries with the same name and uuid. Pkg then
 rejects the manifest with "Invalid manifest format: ...'s dependency on
 <MainPkg> is ambiguous". The path entry must win, since the main package is
-sourced locally, not from the registry.
+sourced locally, not from the registry. The replacement entry retains the
+package's dependency, weak-dependency, and extension metadata so Pkg can load
+extensions without refreshing the locked manifest.
 """
 function add_main_package_to_manifest(manifest_file::String, main_project_file::String; path::String = ".")
     if !isfile(manifest_file)
@@ -659,50 +690,22 @@ function add_main_package_to_manifest(manifest_file::String, main_project_file::
     # Get main package info
     pkg_name = get(main_project, "name", nothing)
     pkg_uuid = get(main_project, "uuid", nothing)
-    pkg_version = get(main_project, "version", nothing)
-
     if pkg_name === nothing || pkg_uuid === nothing
         @warn "Main project missing name or uuid, cannot add to manifest"
         return
     end
 
-    # Drop any resolver-emitted entry for the main package (matched by uuid, so
-    # a renamed-but-same-package stanza is still caught) before appending the
-    # path stanza; a duplicate would make the manifest invalid.
     manifest = TOML.parsefile(manifest_file)
-    removed = remove_manifest_entries_by_uuid!(manifest, pkg_uuid)
+    removed = replace_manifest_path_entry!(manifest, pkg_name, main_project, path)
     if !isempty(removed)
-        open(manifest_file, "w") do io
-            TOML.print(io, manifest; sorted = true)
-        end
         @info "Removed resolver-emitted registry entry for main package $pkg_name"
     end
 
-    # Read the manifest content as text to preserve formatting
-    manifest_content = read(manifest_file, String)
-
-    # Build the entry for the main package
-    entry_lines = String[]
-    push!(entry_lines, "[[deps.$pkg_name]]")
-    push!(entry_lines, "path = \"$path\"")
-    push!(entry_lines, "uuid = \"$pkg_uuid\"")
-    if pkg_version !== nothing
-        push!(entry_lines, "version = \"$pkg_version\"")
-    end
-    push!(entry_lines, "")
-
-    main_pkg_entry = join(entry_lines, "\n")
-
-    # Append the main package entry to the manifest
     open(manifest_file, "w") do io
-        print(io, manifest_content)
-        if !endswith(manifest_content, "\n")
-            println(io)
-        end
-        print(io, main_pkg_entry)
+        TOML.print(io, manifest; sorted = true)
     end
 
-    @info "Added main package $pkg_name to manifest"
+    return @info "Added main package $pkg_name to manifest"
 end
 
 """
@@ -753,7 +756,8 @@ though they remain in the project's `[deps]`. Without this, the build step fails
 with errors like "expected package X to be listed in the manifest" / "X is listed
 in Project.toml but absent from Manifest.toml" (see #3021). Each such package is
 written back as a path dependency pointing at the same location given in
-`[sources]`, mirroring `add_main_package_to_manifest`.
+`[sources]`, mirroring `add_main_package_to_manifest`. Dependency,
+weak-dependency, and extension metadata is copied from each source project.
 
 Packages sourced solely for `[targets].test` are included when this manifest was
 produced from the merged test environment. Active nested path sources are
@@ -780,51 +784,29 @@ function add_source_packages_to_manifest(
     isempty(path_sources) && return
     manifest_dir = abspath(manifest_dir)
 
-    entry_lines = String[]
     added_pkgs = String[]
+    manifest = TOML.parsefile(manifest_file)
+    manifest_deps = get(manifest, "deps", manifest)
     for source in path_sources
         pkg = source.name
         source_path = dirname(source.project_file)
         pkg_path = relpath(source_path, manifest_dir)
         uuid = get(source.project, "uuid", nothing)
-        version = get(source.project, "version", nothing)
-        hard_deps = sort!(collect(keys(get(source.project, "deps", Dict{String, Any}()))))
         if uuid === nothing
             @warn "Could not determine uuid for source package $pkg, skipping manifest entry"
             continue
         end
 
-        push!(entry_lines, "[[deps.$pkg]]")
-        isempty(hard_deps) || push!(entry_lines, "deps = $(repr(hard_deps))")
-        push!(entry_lines, "path = \"$pkg_path\"")
-        push!(entry_lines, "uuid = \"$uuid\"")
-        version !== nothing && push!(entry_lines, "version = \"$version\"")
-        push!(entry_lines, "")
+        had_registry_entry = haskey(manifest_deps, pkg)
+        replace_manifest_path_entry!(manifest, pkg, source.project, pkg_path)
+        had_registry_entry &&
+            @info "Removed resolver-emitted registry entry for source package $pkg"
         push!(added_pkgs, pkg)
         @info "Added source package $pkg to manifest as a path dependency"
     end
-    isempty(entry_lines) && return
-
-    # Drop any resolver-emitted registry entries for the packages we are about
-    # to add as path entries; a duplicate [[deps.X]] makes the manifest invalid.
-    manifest = TOML.parsefile(manifest_file)
-    manifest_deps = get(manifest, "deps", Dict{String, Any}())
-    replaced = filter(pkg -> haskey(manifest_deps, pkg), added_pkgs)
-    if !isempty(replaced)
-        for pkg in replaced
-            delete!(manifest_deps, pkg)
-            @info "Removed resolver-emitted registry entry for source package $pkg"
-        end
-        open(manifest_file, "w") do io
-            TOML.print(io, manifest; sorted = true)
-        end
-    end
-
-    manifest_content = read(manifest_file, String)
-    open(manifest_file, "w") do io
-        print(io, manifest_content)
-        endswith(manifest_content, "\n") || println(io)
-        print(io, join(entry_lines, "\n"))
+    isempty(added_pkgs) && return
+    return open(manifest_file, "w") do io
+        TOML.print(io, manifest; sorted = true)
     end
 end
 
@@ -865,6 +847,10 @@ function resolve_directory(
             if isfile(merged_manifest)
                 cp(merged_manifest, manifest_file; force = true)
 
+                # Promote path-backed test dependencies before recording the main
+                # package so its manifest dependency list matches the final project.
+                promote_test_target_path_sources!(project_file)
+
                 # Add the main package itself and other source packages back to the manifest
                 add_main_package_to_manifest(manifest_file, project_file; path = ".")
                 if !isempty(source_pkgs)
@@ -873,7 +859,6 @@ function resolve_directory(
                         include_test_target = true
                     )
                 end
-                promote_test_target_path_sources!(project_file)
                 set_manifest_project_hash(manifest_file, project_file)
             end
         finally
@@ -1168,6 +1153,11 @@ if do_merge
         cp(merged_manifest, test_manifest; force = true)
         @info "Copied merged manifest to $test_manifest"
 
+        # Promote path-backed test dependencies before recording the main
+        # package so its manifest dependency list matches the final project.
+        promote_test_target_path_sources!(main_project_file)
+        promote_test_target_path_sources!(test_project_file)
+
         # Add the main package itself to the manifest as a path dependency
         # This is needed for workspace projects where the test project depends on the main package
         add_main_package_to_manifest(main_manifest, main_project_file; path = ".")
@@ -1186,10 +1176,6 @@ if do_merge
                 include_test_target = true
             )
         end
-
-        promote_test_target_path_sources!(main_project_file)
-        promote_test_target_path_sources!(test_project_file)
-
         # Ensure each manifest has the project hash corresponding to the project
         # that will consume it (main root and test environment respectively).
         set_manifest_project_hash(main_manifest, main_project_file)

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -139,83 +139,149 @@ function get_source_packages(project_file::String)
     return source_pkgs
 end
 
-"""
-    remove_source_packages_from_project(project_file, source_pkgs)
+struct DirectRuntimePathSource
+    name::String
+    project::Dict{String, Any}
+end
 
-Create a modified version of the Project.toml with source packages
-removed from [deps], [compat], [extras], [sources], and [targets] sections.
-Returns the original content so it can be restored later.
-
-Note: We must also remove from [sources] because Pkg validates that any
-package in [sources] must be in [deps] or [extras]; and from [targets]
-because Pkg validates that any package in a target must be in [deps],
-[weakdeps], or [extras]. A source package that also appears in a test
-target (common in monorepos that dev a sibling package for testing) would
-otherwise leave a dangling target reference once removed from [extras].
-"""
-function remove_source_packages_from_project(project_file::String, source_pkgs::Set{String})
-    if isempty(source_pkgs)
-        return nothing  # No modification needed
+function find_project_file(dir::AbstractString)
+    for filename in ("Project.toml", "JuliaProject.toml")
+        project_file = joinpath(dir, filename)
+        isfile(project_file) && return project_file
     end
-
-    original_content = read(project_file, String)
-    project = TOML.parsefile(project_file)
-    modified = false
-
-    # Remove from [deps], [extras], [compat], and [sources]
-    for section_name in ("deps", "extras", "compat", "sources")
-        haskey(project, section_name) || continue
-        section = project[section_name]
-        for pkg in source_pkgs
-            haskey(section, pkg) || continue
-            delete!(section, pkg)
-            modified = true
-            @info "Temporarily removing $pkg from [$section_name] for resolution"
-        end
-    end
-
-    # Remove from each list in [targets]. A source package removed from [extras]
-    # above but left in a target would fail Pkg validation ("Dependency X in
-    # target test not listed in deps, weakdeps or extras") before resolution runs.
-    if haskey(project, "targets")
-        for (target_name, target_list) in project["targets"]
-            target_list isa AbstractVector || continue
-            for pkg in source_pkgs
-                if pkg in target_list
-                    filter!(!isequal(pkg), target_list)
-                    modified = true
-                    @info "Temporarily removing $pkg from [targets.$target_name] for resolution"
-                end
-            end
-        end
-    end
-
-    # Remove empty [sources] section
-    if haskey(project, "sources") && isempty(project["sources"])
-        delete!(project, "sources")
-    end
-
-    if modified
-        open(project_file, "w") do io
-            TOML.print(io, project)
-        end
-        return original_content
-    end
-
     return nothing
 end
 
 """
-    restore_project_file(project_file, original_content)
+    collect_direct_runtime_path_sources(project_file) -> Vector{DirectRuntimePathSource}
 
-Restore the original Project.toml content after resolution.
+Collect direct local path packages that occur in both runtime `[deps]` and
+`[sources]` in `project_file`. Nested path sources are intentionally not
+traversed.
 """
-function restore_project_file(project_file::String, original_content::Union{
-        String, Nothing})
-    if original_content !== nothing
-        write(project_file, original_content)
-        @info "Restored original Project.toml"
+function collect_direct_runtime_path_sources(project_file::String)
+    root_file = abspath(project_file)
+    root_dir = dirname(root_file)
+    root_project = TOML.parsefile(root_file)
+    deps = get(root_project, "deps", Dict{String, Any}())
+    sources = get(root_project, "sources", Dict{String, Any}())
+    result = DirectRuntimePathSource[]
+
+    for name in sort!(collect(keys(sources)))
+        haskey(deps, name) || continue
+        source = sources[name]
+        source isa AbstractDict || continue
+        haskey(source, "path") || continue
+
+        source_dir = normpath(abspath(joinpath(root_dir, source["path"])))
+        source_file = find_project_file(source_dir)
+        source_file === nothing &&
+            error("Path source $name from $root_file has no project file at $source_dir")
+        source_project = TOML.parsefile(source_file)
+        declared_name = get(source_project, "name", name)
+        declared_name == name ||
+            error("Path source $name from $root_file declares package name $declared_name")
+        declared_uuid = get(source_project, "uuid", nothing)
+        declared_uuid == deps[name] || error(
+            "Path source $name from $root_file has uuid $declared_uuid, expected $(deps[name])"
+        )
+        push!(result, DirectRuntimePathSource(name, source_project))
     end
+
+    return result
+end
+
+"""
+    add_direct_path_source_dependencies!(merged, project_files)
+
+Add hard registry dependencies that are missing from `merged` but required by a
+direct runtime path source in `project_files`. Dependencies already owned by the
+root project keep the root UUID and compat unchanged. When two path sources add
+the same missing dependency, their UUIDs and any compat strings must agree.
+
+This intentionally does not traverse nested path sources, include dependencies
+from a path package's `[weakdeps]`, or intersect differing compat specifications.
+The locked package build and tests remain responsible for validating root-owned
+dependency versions against the path package.
+"""
+function add_direct_path_source_dependencies!(merged, project_files::Vector{String})
+    path_sources = reduce(
+        vcat, collect_direct_runtime_path_sources.(project_files);
+        init = DirectRuntimePathSource[]
+    )
+    isempty(path_sources) && return
+
+    deps = get!(merged, "deps", Dict{String, Any}())
+    compat = get!(merged, "compat", Dict{String, Any}())
+    weakdeps = get(merged, "weakdeps", Dict{String, Any}())
+    root_owned = Set(keys(deps))
+    local_source_names = Set(source.name for source in path_sources)
+    promoted_by = Dict{String, String}()
+
+    for source in path_sources
+        source_deps = get(source.project, "deps", Dict{String, Any}())
+        source_compat = get(source.project, "compat", Dict{String, Any}())
+        for name in sort!(collect(keys(source_deps)))
+            uuid = source_deps[name]
+            if name in local_source_names
+                @info "Leaving direct path dependency $name local while reading $(source.name)"
+                continue
+            end
+
+            if name in root_owned
+                deps[name] == uuid || error(
+                    "Root dependency $name has uuid $(deps[name]), but path source " *
+                    "$(source.name) requires $uuid"
+                )
+                continue
+            end
+
+            if haskey(weakdeps, name)
+                weakdeps[name] == uuid || error(
+                    "Root weak dependency $name has uuid $(weakdeps[name]), but path " *
+                    "source $(source.name) requires $uuid"
+                )
+                deps[name] = uuid
+                delete!(weakdeps, name)
+                isempty(weakdeps) && delete!(merged, "weakdeps")
+                push!(root_owned, name)
+                @info "Promoting root weak dependency required by $(source.name): $name"
+                continue
+            end
+
+            constraint = get(source_compat, name, nothing)
+            if haskey(promoted_by, name)
+                deps[name] == uuid || error(
+                    "Path sources $(promoted_by[name]) and $(source.name) require " *
+                    "$name with different uuids $(deps[name]) and $uuid"
+                )
+                if constraint !== nothing && haskey(compat, name) &&
+                        compat[name] != constraint
+                    error(
+                        "Path sources $(promoted_by[name]) and $(source.name) require " *
+                        "$name with different compat entries $(compat[name]) and $constraint"
+                    )
+                elseif constraint !== nothing
+                    compat[name] = constraint
+                end
+                continue
+            end
+
+            deps[name] = uuid
+            promoted_by[name] = source.name
+            if constraint !== nothing
+                if haskey(compat, name) && compat[name] != constraint
+                    error(
+                        "Project compat for promoted dependency $name is $(compat[name]), " *
+                        "but path source $(source.name) requires $constraint"
+                    )
+                end
+                compat[name] = constraint
+            end
+            @info "Adding runtime dependency from direct path source $(source.name): $name"
+        end
+    end
+    return
 end
 
 """
@@ -250,8 +316,7 @@ function create_merged_project(main_project_file::String, test_project_file::Str
     # own unregistered lib/* sources). The merge logic below already skips ADDING
     # source packages from extras/test-deps, but a source package listed directly
     # in the main project's [deps] (a monorepo root depending on its siblings)
-    # would otherwise survive the deepcopy. This mirrors the non-merged path's
-    # remove_source_packages_from_project. They are re-added to the manifest as
+    # would otherwise survive the deepcopy. They are re-added to the manifest as
     # path deps after resolution (add_source_packages_to_manifest).
     for section_name in ("deps", "compat", "sources")
         if haskey(merged, section_name)
@@ -356,6 +421,10 @@ function create_merged_project(main_project_file::String, test_project_file::Str
     if haskey(merged, "weakdeps") && isempty(merged["weakdeps"])
         delete!(merged, "weakdeps")
     end
+
+    project_files = main_project_file == test_project_file ?
+                    [main_project_file] : [main_project_file, test_project_file]
+    add_direct_path_source_dependencies!(merged, project_files)
 
     # Write merged project
     mkpath(merged_dir)
@@ -549,8 +618,7 @@ written back as a path dependency pointing at the same location given in
 
 Note: only packages that are themselves in `[deps]` need to be in this manifest;
 packages sourced solely for a test target are not part of the resolved
-environment. The path packages' own (unique) transitive dependencies are not
-re-resolved here, so a fully locked test of those is out of scope for this step.
+environment. Nested path sources are not followed.
 
 If the resolver already emitted a registry entry for a source package (which
 happens whenever another resolved package depends on it), that entry is removed
@@ -639,8 +707,8 @@ end
 """
     resolve_directory(dir, resolver_path, resolver_mode, julia_version, mode, ignore_pkgs, no_promote)
 
-Resolve dependencies for a single directory. Handles source packages by temporarily
-removing them from the project file, running the resolver, and then restoring the original.
+Resolve dependencies for a single directory. Source packages are omitted from a
+temporary merged project and restored to the resolved manifest as path entries.
 Returns the source packages found in the directory (for use in forcedeps checking).
 """
 function resolve_directory(
@@ -683,24 +751,26 @@ function resolve_directory(
             rm(merged_dir, recursive = true)
         end
     else
-        # Handle packages with [sources] entries (e.g., test/Project.toml referencing main package)
-        # These packages cannot be resolved from the registry, so we temporarily remove them
         source_pkgs = get_source_packages(project_file)
-        original_content = remove_source_packages_from_project(project_file, source_pkgs)
-
-        try
+        if isempty(source_pkgs)
             @info "Running resolver on $dir with --min=@$resolver_mode"
             run(`$(Base.julia_cmd()) --project=$resolver_path/bin $resolver_path/bin/resolve.jl $dir --min=@$resolver_mode --julia=$julia_version`)
             @info "Successfully resolved minimal versions for $dir"
-        finally
-            # Always restore the original Project.toml, even if resolution fails
-            restore_project_file(project_file, original_content)
-        end
+        else
+            merged_dir = mktempdir()
+            source_pkgs = create_merged_project(
+                project_file, project_file, merged_dir; no_promote
+            )
+            try
+                @info "Running resolver on $dir with path-source constraints and --min=@$resolver_mode"
+                run(`$(Base.julia_cmd()) --project=$resolver_path/bin $resolver_path/bin/resolve.jl $merged_dir --min=@$resolver_mode --julia=$julia_version`)
+                @info "Successfully resolved minimal versions for $dir with path-source constraints"
+                merged_manifest = joinpath(merged_dir, "Manifest.toml")
+                isfile(merged_manifest) && cp(merged_manifest, manifest_file; force = true)
+            finally
+                rm(merged_dir, recursive = true)
+            end
 
-        # Re-add local path-sourced packages (removed for resolution) to the manifest
-        # so the resolved environment is complete enough to instantiate/build (#3021),
-        # then refresh the project hash so Pkg sees the manifest as up to date.
-        if !isempty(source_pkgs)
             add_source_packages_to_manifest(manifest_file, project_file, dir, source_pkgs)
         end
         set_manifest_project_hash(manifest_file, project_file)

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -403,35 +403,35 @@ function test_only_path_source_dependencies(
 end
 
 function parse_compat_constraint(constraint)
-    # Pkg exposes no public top-level parser for Project.toml's compat grammar.
-    # Keep the internal access isolated here instead of duplicating that grammar.
+    # Pkg exposes no public parser or serializer for Project.toml's compat
+    # grammar. The internal access is isolated here and in compat_constraint_string
+    # instead of duplicating that grammar.
     return Pkg.Versions.semver_spec(constraint)
 end
 
-function compat_constraint_string(spec)
-    raw = string(spec)
-    if startswith(raw, "[") && endswith(raw, "]")
-        raw = raw[2:(end - 1)]
-    end
+# A VersionBound holds up to three significant components in `t`, with `n`
+# recording how many are set (`n == 0` is an unbounded end). These fields are
+# stable across the Julia versions this action supports, unlike the printed form
+# of a VersionSpec, whose hyphen spacing changed between 1.10 and 1.11.
+compat_bound_string(bound) = join(bound.t[1:bound.n], '.')
 
-    ranges = map(split(raw, ", ")) do range
-        if (m = match(r"^([0-9]+(?:\.[0-9]+){0,2})-\*$", range)) !== nothing
-            return ">=" * m.captures[1]
-        elseif (
-                m = match(
-                    r"^([0-9]+(?:\.[0-9]+){0,2})-([0-9]+(?:\.[0-9]+){0,2})$",
-                    range
-                )
-            ) !== nothing
-            return m.captures[1] * " - " * m.captures[2]
-        elseif occursin(r"^[1-9][0-9]*\.[0-9]+$", range)
-            return "~" * range
-        elseif occursin(r"^[0-9]+\.[0-9]+\.[0-9]+$", range)
-            return "=" * range
-        end
-        return range
-    end
-    constraint = join(ranges, ", ")
+function compat_range_string(range)
+    lower, upper = range.lower, range.upper
+    # A [compat] floor always has a lower bound, so intersections of real compat
+    # entries never yield one without it; refuse rather than emit a spec that
+    # semver_spec cannot parse back.
+    lower.n == 0 && error("Cannot serialize a compat constraint with no lower bound")
+    upper.n == 0 && return ">= " * compat_bound_string(lower)
+    return compat_bound_string(lower) * " - " * compat_bound_string(upper)
+end
+
+function compat_constraint_string(spec)
+    # Serialize each VersionRange as an explicit two-endpoint compat range read
+    # from the parsed bounds, so the result round-trips through
+    # parse_compat_constraint independently of how Pkg renders the spec. The
+    # assertion turns any unforeseen range shape into a loud error rather than a
+    # silently wrong constraint.
+    constraint = join((compat_range_string(range) for range in spec.ranges), ", ")
     parse_compat_constraint(constraint) == spec || error(
         "Could not serialize intersected compat constraint $spec"
     )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -521,6 +521,8 @@ end
                         "@test WeakTool.loaded()\n"
                 )
 
+                original_project = read(joinpath("SubPackage", "Project.toml"), String)
+
                 # Before the fix this throws a ProcessFailedException.
                 run(`$(Base.julia_cmd()) $downgrade_jl "" "SubPackage" "deps" "1"`)
 
@@ -534,23 +536,34 @@ end
                 @test devtool["path"] == "../DevTool"
                 @test Set(devtool["deps"]) == Set(["DataStructures"])
                 @test only(manifest["deps"]["WeakTool"])["path"] == "../WeakTool"
+                expected_main_deps = VERSION >= v"1.11" ?
+                                     Set(["DataStructures", "JSON"]) :
+                                     Set(["DevTool", "JSON", "WeakTool"])
                 @test Set(only(manifest["deps"]["SubPackage"])["deps"]) ==
-                    Set(["DevTool", "JSON", "WeakTool"])
+                    expected_main_deps
                 run(`$(Base.julia_cmd()) --project=SubPackage -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
 
-                # Pkg.test only preserves the locked path package when it is a
-                # runtime dependency. Its source and test target remain intact.
                 restored = TOML.parsefile(joinpath("SubPackage", "Project.toml"))
                 @test restored["targets"]["test"] == ["DevTool", "Test", "WeakTool"]
                 @test haskey(restored["sources"], "DevTool")
                 @test haskey(restored["sources"], "WeakTool")
-                @test restored["deps"]["DevTool"] ==
-                    "11111111-1111-1111-1111-111111111111"
-                @test restored["deps"]["WeakTool"] ==
-                    "77777777-7777-7777-7777-777777777777"
                 @test haskey(restored["extras"], "DevTool")
                 @test haskey(restored["extras"], "WeakTool")
-                @test !haskey(restored, "weakdeps")
+                if VERSION >= v"1.11"
+                    @test read(joinpath("SubPackage", "Project.toml"), String) !=
+                        original_project
+                    @test restored["deps"]["DataStructures"] ==
+                        "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+                    @test !haskey(restored["deps"], "DevTool")
+                    @test !haskey(restored["deps"], "WeakTool")
+                    @test haskey(restored, "weakdeps")
+                else
+                    @test restored["deps"]["DevTool"] ==
+                        "11111111-1111-1111-1111-111111111111"
+                    @test restored["deps"]["WeakTool"] ==
+                        "77777777-7777-7777-7777-777777777777"
+                    @test !haskey(restored, "weakdeps")
+                end
 
                 mkdir("WeakOnlyPackage")
                 write(
@@ -584,14 +597,27 @@ end
                     "using WeakTool\nWeakTool.loaded() || error(\"WeakTool failed to load\")\n"
                 )
 
+                original_weak_project =
+                    read(joinpath("WeakOnlyPackage", "Project.toml"), String)
+
                 run(`$(Base.julia_cmd()) $downgrade_jl "" "WeakOnlyPackage" "deps" "1"`)
                 run(`$(Base.julia_cmd()) --project=WeakOnlyPackage -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
                 weak_only = TOML.parsefile(joinpath("WeakOnlyPackage", "Project.toml"))
-                @test weak_only["deps"]["WeakTool"] ==
-                    "77777777-7777-7777-7777-777777777777"
-                @test weak_only["extras"]["WeakTool"] ==
-                    "77777777-7777-7777-7777-777777777777"
-                @test !haskey(weak_only, "weakdeps")
+                if VERSION >= v"1.11"
+                    @test read(joinpath("WeakOnlyPackage", "Project.toml"), String) !=
+                        original_weak_project
+                    @test !haskey(weak_only, "deps")
+                    @test weak_only["extras"]["WeakTool"] ==
+                        "77777777-7777-7777-7777-777777777777"
+                    @test weak_only["weakdeps"]["WeakTool"] ==
+                        "77777777-7777-7777-7777-777777777777"
+                else
+                    @test weak_only["deps"]["WeakTool"] ==
+                        "77777777-7777-7777-7777-777777777777"
+                    @test weak_only["extras"]["WeakTool"] ==
+                        "77777777-7777-7777-7777-777777777777"
+                    @test !haskey(weak_only, "weakdeps")
+                end
             end
         end
     end
@@ -1120,8 +1146,8 @@ end
                     DataStructures = "0.18"
                     julia = "1.10"
                     JSON = "0.21"
-                    Preferences = "~1.4"
-                    StaticArrays = "1.9.8"
+                    Preferences = "1.4.0"
+                    StaticArrays = "1.8, 1.9"
                     """
                 )
                 write(
@@ -1143,7 +1169,7 @@ end
 
                     [compat]
                     julia = "1.10"
-                    Preferences = ">=1.3"
+                    Preferences = "1"
                     StaticArrays = "1.9.8"
                     """
                 )
@@ -1176,7 +1202,6 @@ end
                     LocalB = {path = "LocalB"}
 
                     [compat]
-                    DataStructures = "0.18.0"
                     julia = "1.10"
                     BenchmarkTools = "1.5.0"
                     JSON = "0.21.4"
@@ -1211,6 +1236,8 @@ end
                     Set(["DataStructures", "JSON", "Preferences", "StaticArrays"])
                 @test local_b["path"] == "LocalB"
                 @test Set(local_b["deps"]) == Set(["Preferences", "StaticArrays"])
+                @test Set(only(deps["RootPkg"])["deps"]) ==
+                    Set(["JSON", "LocalA", "LocalB"])
                 run(`$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
 
                 restored = TOML.parsefile("Project.toml")
@@ -1348,6 +1375,17 @@ end
                 )
                 write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing StaticArrays\nend\n")
 
+                mkpath("LocalTest/src")
+                write(
+                    "LocalTest/Project.toml",
+                    """
+                    name = "LocalTest"
+                    uuid = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                    version = "0.1.0"
+                    """
+                )
+                write("LocalTest/src/LocalTest.jl", "module LocalTest\nend\n")
+
                 mkpath("src")
                 mkpath("test")
                 write("src/RootPkg.jl", "module RootPkg\nusing LocalDep\nend\n")
@@ -1368,13 +1406,21 @@ end
 
                     [sources]
                     LocalDep = {path = "LocalDep"}
+                    LocalTest = {path = "LocalTest"}
 
                     [compat]
                     julia = "1.10"
                     JSON = "0.21.4"
                     LocalDep = "0.1"
+
+                    [extras]
+                    LocalTest = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+
+                    [targets]
+                    test = ["LocalTest"]
                     """
                 )
+                original_project = read("Project.toml", String)
                 write(
                     "test/Project.toml",
                     """
@@ -1400,10 +1446,18 @@ end
                 @test only(main_deps["JSON"])["version"] == "0.21.4"
                 @test only(main_deps["BenchmarkTools"])["version"] == "1.5.0"
                 @test only(main_deps["LocalDep"])["path"] == "LocalDep"
+                @test only(main_deps["LocalTest"])["path"] == "LocalTest"
                 @test only(test_deps["LocalDep"])["path"] == "../LocalDep"
+                @test only(test_deps["LocalTest"])["path"] == "../LocalTest"
                 @test only(main_deps["RootPkg"])["path"] == "."
                 @test only(test_deps["RootPkg"])["path"] == ".."
-                @test Set(only(test_deps["RootPkg"])["deps"]) == Set(["JSON", "LocalDep"])
+                expected_root_deps = VERSION >= v"1.11" ?
+                                     Set(["JSON", "LocalDep"]) :
+                                     Set(["JSON", "LocalDep", "LocalTest"])
+                @test Set(only(test_deps["RootPkg"])["deps"]) == expected_root_deps
+                if VERSION >= v"1.11"
+                    @test read("Project.toml", String) == original_project
+                end
 
                 locked = Dict(
                     name => only(test_deps[name])["version"]
@@ -1418,7 +1472,7 @@ end
         end
     end
 
-    @testset "locked tests reject an incompatible root-owned path dependency floor" begin
+    @testset "root and path-source compat constraints must overlap" begin
         mktempdir() do dir
             cd(dir) do
                 mkpath("LocalDep/src")
@@ -1469,22 +1523,20 @@ end
                     """
                 )
 
-                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`)
-                manifest = TOML.parsefile("Manifest.toml")
-                @test only(manifest["deps"]["JSON"])["version"] == "0.21.4"
-
                 output = IOBuffer()
                 process = run(
                     pipeline(
-                        `$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`;
+                        `$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`;
                         stdout = output, stderr = output
                     ); wait = false
                 )
                 wait(process)
                 log = String(take!(output))
                 @test !success(process)
-                @test occursin("JSON", log)
-                @test occursin("compat", lowercase(log)) || occursin("0.20", log)
+                @test occursin(
+                    "Root project and path source LocalDep require JSON with disjoint compat entries",
+                    log
+                )
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1614,6 +1614,81 @@ end
         end
     end
 
+    @testset "direct path sources intersect overlapping compat for a promoted dependency" begin
+        mktempdir() do dir
+            cd(dir) do
+                # Two path sources constrain a shared registry dependency with
+                # overlapping, lower-bounded-only ranges. Their intersection is
+                # open-upper, so the serializer must emit ">= 0.18.0"; the earlier
+                # string(spec)+regex approach instead emitted the unparseable
+                # "0.18.0 - *" on Julia 1.11+ and aborted the resolution.
+                for (name, uuid, constraint) in (
+                        ("LocalA", "44444444-4444-4444-4444-444444444444", ">= 0.17"),
+                        ("LocalB", "66666666-6666-6666-6666-666666666666", ">= 0.18"),
+                    )
+                    mkpath("$name/src")
+                    write(
+                        "$name/Project.toml",
+                        """
+                        name = "$name"
+                        uuid = "$uuid"
+                        version = "0.1.0"
+
+                        [deps]
+                        DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                        [compat]
+                        DataStructures = "$constraint"
+                        """
+                    )
+                    write("$name/src/$name.jl", "module $name\nend\n")
+                end
+                mkdir("test")
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "55555555-5555-5555-5555-555555555555"
+                    version = "0.1.0"
+
+                    [deps]
+                    LocalA = "44444444-4444-4444-4444-444444444444"
+
+                    [sources]
+                    LocalA = {path = "LocalA"}
+
+                    [compat]
+                    julia = "1.10"
+                    LocalA = "0.1"
+                    """
+                )
+                write(
+                    "test/Project.toml",
+                    """
+                    [deps]
+                    LocalB = "66666666-6666-6666-6666-666666666666"
+                    RootPkg = "55555555-5555-5555-5555-555555555555"
+
+                    [sources]
+                    LocalB = {path = "../LocalB"}
+                    RootPkg = {path = ".."}
+
+                    [compat]
+                    LocalB = "0.1"
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" ".,test" "deps" "1.10"`)
+
+                @test isfile("Manifest.toml")
+                manifest = TOML.parsefile("Manifest.toml")
+                # 0.18.0 is the intersection floor; LocalA's ">= 0.17" alone would
+                # resolve to 0.17.x, so this also confirms the intersection applied.
+                @test only(manifest["deps"]["DataStructures"])["version"] == "0.18.0"
+            end
+        end
+    end
+
     @testset "no_promote keeps a named weakdep extension out of the joint resolve" begin
         # The merged resolution promotes every weakdep test-extra into ONE joint
         # floor-resolve -- correct, because the extensions coexist in a single test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -534,6 +534,8 @@ end
                 @test devtool["path"] == "../DevTool"
                 @test Set(devtool["deps"]) == Set(["DataStructures"])
                 @test only(manifest["deps"]["WeakTool"])["path"] == "../WeakTool"
+                @test Set(only(manifest["deps"]["SubPackage"])["deps"]) ==
+                    Set(["DevTool", "JSON", "WeakTool"])
                 run(`$(Base.julia_cmd()) --project=SubPackage -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
 
                 # Pkg.test only preserves the locked path package when it is a
@@ -603,32 +605,53 @@ end
             cd(dir) do
                 # Locally-developed dependency referenced by path.
                 mkdir("CorePkg")
-                write("CorePkg/Project.toml", """
-                name = "CorePkg"
-                uuid = "33333333-3333-3333-3333-333333333333"
-                version = "1.2.3"
-                """)
+                write(
+                    "CorePkg/Project.toml", """
+                    name = "CorePkg"
+                    uuid = "33333333-3333-3333-3333-333333333333"
+                    version = "1.2.3"
+
+                    [weakdeps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [extensions]
+                    CorePkgJSONExt = "JSON"
+                    """
+                )
                 mkdir("CorePkg/src")
-                write("CorePkg/src/CorePkg.jl", "module CorePkg\nend\n")
+                write(
+                    "CorePkg/src/CorePkg.jl",
+                    "module CorePkg\nfunction extension_loaded end\nend\n"
+                )
+                mkdir("CorePkg/ext")
+                write(
+                    "CorePkg/ext/CorePkgJSONExt.jl",
+                    "module CorePkgJSONExt\n" *
+                        "using CorePkg, JSON\n" *
+                        "CorePkg.extension_loaded() = true\n" *
+                        "end\n"
+                )
 
                 # Package under test: a registry dep plus a path-sourced dep in [deps].
                 mkdir("SubPackage")
-                write("SubPackage/Project.toml", """
-                name = "SubPackage"
-                uuid = "44444444-4444-4444-4444-444444444444"
-                version = "0.1.0"
+                write(
+                    "SubPackage/Project.toml", """
+                    name = "SubPackage"
+                    uuid = "44444444-4444-4444-4444-444444444444"
+                    version = "0.1.0"
 
-                [deps]
-                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-                CorePkg = "33333333-3333-3333-3333-333333333333"
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    CorePkg = "33333333-3333-3333-3333-333333333333"
 
-                [sources]
-                CorePkg = {path = "../CorePkg"}
+                    [sources]
+                    CorePkg = {path = "../CorePkg"}
 
-                [compat]
-                julia = "1.10"
-                JSON = "0.20, 0.21"
-                """)
+                    [compat]
+                    julia = "1.10"
+                    JSON = "0.20, 0.21"
+                    """
+                )
 
                 run(`$(Base.julia_cmd()) $downgrade_jl "" "SubPackage" "deps" "1.10"`)
 
@@ -648,10 +671,14 @@ end
                 @test core_entry[1]["path"] == "../CorePkg"
                 @test core_entry[1]["uuid"] == "33333333-3333-3333-3333-333333333333"
                 @test core_entry[1]["version"] == "1.2.3"
+                @test core_entry[1]["extensions"]["CorePkgJSONExt"] == "JSON"
+                @test core_entry[1]["weakdeps"]["JSON"] ==
+                    "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                run(`$(Base.julia_cmd()) --project=SubPackage -e 'using CorePkg, JSON; CorePkg.extension_loaded() || error("path-source extension did not load")'`)
 
                 # Project hash matches what Pkg expects for the restored project.
                 @test manifest["project_hash"] ==
-                      expected_project_hash(joinpath(dir, "SubPackage", "Project.toml"))
+                    expected_project_hash(joinpath(dir, "SubPackage", "Project.toml"))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -441,55 +441,155 @@ end
             cd(dir) do
                 # Sibling package that is dev'd via a local path source.
                 mkdir("DevTool")
-                write("DevTool/Project.toml", """
-                name = "DevTool"
-                uuid = "11111111-1111-1111-1111-111111111111"
-                version = "0.1.0"
-                """)
+                write(
+                    "DevTool/Project.toml", """
+                    name = "DevTool"
+                    uuid = "11111111-1111-1111-1111-111111111111"
+                    version = "0.1.0"
+
+                    [deps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [compat]
+                    DataStructures = "0.18"
+                    """
+                )
                 mkdir("DevTool/src")
-                write("DevTool/src/DevTool.jl", "module DevTool\nend\n")
+                write(
+                    "DevTool/src/DevTool.jl",
+                    "module DevTool\n" *
+                        "using DataStructures\n" *
+                        "loaded() = OrderedDict(:ok => true)[:ok]\n" *
+                        "dependency_version() = Base.pkgversion(DataStructures)\n" *
+                        "end\n"
+                )
+
+                mkdir("WeakTool")
+                write(
+                    "WeakTool/Project.toml", """
+                    name = "WeakTool"
+                    uuid = "77777777-7777-7777-7777-777777777777"
+                    version = "0.1.0"
+                    """
+                )
+                mkdir("WeakTool/src")
+                write(
+                    "WeakTool/src/WeakTool.jl",
+                    "module WeakTool\nloaded() = true\nend\n"
+                )
 
                 # Package under test: a registry dep plus a path-sourced test dep
                 # that is referenced from [targets].
                 mkdir("SubPackage")
-                write("SubPackage/Project.toml", """
-                name = "SubPackage"
-                uuid = "22222222-2222-2222-2222-222222222222"
-                version = "0.1.0"
+                write(
+                    "SubPackage/Project.toml", """
+                    name = "SubPackage"
+                    uuid = "22222222-2222-2222-2222-222222222222"
+                    version = "0.1.0"
 
-                [deps]
-                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 
-                [extras]
-                DevTool = "11111111-1111-1111-1111-111111111111"
-                Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+                    [extras]
+                    DevTool = "11111111-1111-1111-1111-111111111111"
+                    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+                    WeakTool = "77777777-7777-7777-7777-777777777777"
 
-                [sources]
-                DevTool = {path = "../DevTool"}
+                    [weakdeps]
+                    WeakTool = "77777777-7777-7777-7777-777777777777"
 
-                [compat]
-                julia = "1.10"
-                JSON = "0.20, 0.21"
+                    [sources]
+                    DevTool = {path = "../DevTool"}
+                    WeakTool = {path = "../WeakTool"}
 
-                [targets]
-                test = ["DevTool", "Test"]
-                """)
+                    [compat]
+                    julia = "1.10"
+                    JSON = "0.20, 0.21"
+
+                    [targets]
+                    test = ["DevTool", "Test", "WeakTool"]
+                    """
+                )
+                mkdir("SubPackage/src")
+                write("SubPackage/src/SubPackage.jl", "module SubPackage\nend\n")
+                mkdir("SubPackage/test")
+                write(
+                    "SubPackage/test/runtests.jl",
+                    "using DevTool, Test, WeakTool\n" *
+                        "@test DevTool.loaded()\n" *
+                        "@test DevTool.dependency_version() == v\"0.18.0\"\n" *
+                        "@test WeakTool.loaded()\n"
+                )
 
                 # Before the fix this throws a ProcessFailedException.
-                run(`$(Base.julia_cmd()) $downgrade_jl "" "SubPackage" "deps" "1.10"`)
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "SubPackage" "deps" "1"`)
 
                 @test isfile(joinpath("SubPackage", "Manifest.toml"))
                 manifest = TOML.parsefile(joinpath("SubPackage", "Manifest.toml"))
                 deps_JSON = get(manifest["deps"], "JSON", [])
                 @test !isempty(deps_JSON)
                 @test startswith(deps_JSON[1]["version"], "0.20")
+                @test only(manifest["deps"]["DataStructures"])["version"] == "0.18.0"
+                devtool = only(manifest["deps"]["DevTool"])
+                @test devtool["path"] == "../DevTool"
+                @test Set(devtool["deps"]) == Set(["DataStructures"])
+                @test only(manifest["deps"]["WeakTool"])["path"] == "../WeakTool"
+                run(`$(Base.julia_cmd()) --project=SubPackage -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
 
-                # The original Project.toml must be restored verbatim, including
-                # the [targets] and [sources] entries that were stripped.
+                # Pkg.test only preserves the locked path package when it is a
+                # runtime dependency. Its source and test target remain intact.
                 restored = TOML.parsefile(joinpath("SubPackage", "Project.toml"))
-                @test restored["targets"]["test"] == ["DevTool", "Test"]
+                @test restored["targets"]["test"] == ["DevTool", "Test", "WeakTool"]
                 @test haskey(restored["sources"], "DevTool")
+                @test haskey(restored["sources"], "WeakTool")
+                @test restored["deps"]["DevTool"] ==
+                    "11111111-1111-1111-1111-111111111111"
+                @test restored["deps"]["WeakTool"] ==
+                    "77777777-7777-7777-7777-777777777777"
                 @test haskey(restored["extras"], "DevTool")
+                @test haskey(restored["extras"], "WeakTool")
+                @test !haskey(restored, "weakdeps")
+
+                mkdir("WeakOnlyPackage")
+                write(
+                    "WeakOnlyPackage/Project.toml", """
+                    name = "WeakOnlyPackage"
+                    uuid = "88888888-8888-8888-8888-888888888888"
+                    version = "0.1.0"
+
+                    [weakdeps]
+                    WeakTool = "77777777-7777-7777-7777-777777777777"
+
+                    [sources]
+                    WeakTool = {path = "../WeakTool"}
+
+                    [compat]
+                    julia = "1.10"
+                    WeakTool = "0.1"
+
+                    [targets]
+                    test = ["WeakTool"]
+                    """
+                )
+                mkdir("WeakOnlyPackage/src")
+                write(
+                    "WeakOnlyPackage/src/WeakOnlyPackage.jl",
+                    "module WeakOnlyPackage\nend\n"
+                )
+                mkdir("WeakOnlyPackage/test")
+                write(
+                    "WeakOnlyPackage/test/runtests.jl",
+                    "using WeakTool\nWeakTool.loaded() || error(\"WeakTool failed to load\")\n"
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "WeakOnlyPackage" "deps" "1"`)
+                run(`$(Base.julia_cmd()) --project=WeakOnlyPackage -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
+                weak_only = TOML.parsefile(joinpath("WeakOnlyPackage", "Project.toml"))
+                @test weak_only["deps"]["WeakTool"] ==
+                    "77777777-7777-7777-7777-777777777777"
+                @test weak_only["extras"]["WeakTool"] ==
+                    "77777777-7777-7777-7777-777777777777"
+                @test !haskey(weak_only, "weakdeps")
             end
         end
     end
@@ -986,18 +1086,20 @@ end
                     [deps]
                     DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
                     JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    Preferences = "21216c6a-2e73-6563-6e65-726566657250"
                     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
                     [compat]
                     DataStructures = "0.18"
                     julia = "1.10"
                     JSON = "0.21"
+                    Preferences = "~1.4"
                     StaticArrays = "1.9.8"
                     """
                 )
                 write(
                     "LocalA/src/LocalA.jl",
-                    "module LocalA\nusing DataStructures, JSON, StaticArrays\nend\n"
+                    "module LocalA\nusing DataStructures, JSON, Preferences, StaticArrays\nend\n"
                 )
 
                 mkpath("LocalB/src")
@@ -1009,14 +1111,19 @@ end
                     version = "0.1.0"
 
                     [deps]
+                    Preferences = "21216c6a-2e73-6563-6e65-726566657250"
                     StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
                     [compat]
                     julia = "1.10"
+                    Preferences = ">=1.3"
                     StaticArrays = "1.9.8"
                     """
                 )
-                write("LocalB/src/LocalB.jl", "module LocalB\nusing StaticArrays\nend\n")
+                write(
+                    "LocalB/src/LocalB.jl",
+                    "module LocalB\nusing Preferences, StaticArrays\nend\n"
+                )
 
                 mkpath("src")
                 mkpath("test")
@@ -1066,6 +1173,7 @@ end
                 manifest = TOML.parsefile("Manifest.toml")
                 deps = manifest["deps"]
                 @test only(deps["DataStructures"])["version"] == "0.18.0"
+                @test only(deps["Preferences"])["version"] == "1.4.0"
                 @test only(deps["StaticArrays"])["version"] == "1.9.8"
                 @test only(deps["JSON"])["version"] == "0.21.4"
                 @test only(deps["BenchmarkTools"])["version"] == "1.5.0"
@@ -1073,16 +1181,122 @@ end
                 local_b = only(deps["LocalB"])
                 @test local_a["path"] == "LocalA"
                 @test Set(local_a["deps"]) ==
-                      Set(["DataStructures", "JSON", "StaticArrays"])
+                    Set(["DataStructures", "JSON", "Preferences", "StaticArrays"])
                 @test local_b["path"] == "LocalB"
-                @test Set(local_b["deps"]) == Set(["StaticArrays"])
+                @test Set(local_b["deps"]) == Set(["Preferences", "StaticArrays"])
                 run(`$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
 
                 restored = TOML.parsefile("Project.toml")
                 @test Set(keys(restored["sources"])) == Set(["LocalA", "LocalB"])
                 @test haskey(restored["weakdeps"], "DataStructures")
                 @test !haskey(restored["deps"], "DataStructures")
+                @test !haskey(restored["deps"], "Preferences")
                 @test !haskey(restored["deps"], "StaticArrays")
+            end
+        end
+    end
+
+    @testset "nested path sources remain local and constrain minimum resolution" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalB/src")
+                write(
+                    "LocalB/Project.toml",
+                    """
+                    name = "LocalB"
+                    uuid = "44444444-4444-4444-4444-444444444444"
+                    version = "0.1.0"
+
+                    [deps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [compat]
+                    DataStructures = "0.18"
+                    julia = "1.10"
+                    """
+                )
+                write(
+                    "LocalB/src/LocalB.jl",
+                    "module LocalB\nusing DataStructures\nconst selected_version = Base.pkgversion(DataStructures)\nend\n"
+                )
+
+                mkpath("LocalA/src")
+                write(
+                    "LocalA/Project.toml",
+                    """
+                    name = "LocalA"
+                    uuid = "55555555-5555-5555-5555-555555555555"
+                    version = "0.1.0"
+
+                    [deps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+                    LocalB = "44444444-4444-4444-4444-444444444444"
+
+                    [sources.LocalB]
+                    path = "../LocalB"
+
+                    [compat]
+                    DataStructures = "0.18.1"
+                    LocalB = "0.1"
+                    julia = "1.10"
+                    """
+                )
+                write(
+                    "LocalA/src/LocalA.jl",
+                    "module LocalA\nusing DataStructures, LocalB\nconst selected_version = LocalB.selected_version\nend\n"
+                )
+
+                mkpath("src")
+                mkpath("test")
+                write(
+                    "src/RootPkg.jl",
+                    "module RootPkg\nusing LocalA\nconst selected_version = LocalA.selected_version\nend\n"
+                )
+                write(
+                    "test/runtests.jl",
+                    "using RootPkg, Test\n@test RootPkg.selected_version == v\"0.18.1\"\n"
+                )
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "66666666-6666-6666-6666-666666666666"
+                    version = "0.1.0"
+
+                    [deps]
+                    LocalA = "55555555-5555-5555-5555-555555555555"
+
+                    [sources.LocalA]
+                    path = "LocalA"
+
+                    [compat]
+                    LocalA = "0.1"
+                    Test = "1.10"
+                    julia = "1.10"
+
+                    [extras]
+                    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+                    [targets]
+                    test = ["Test"]
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1"`)
+
+                manifest = TOML.parsefile("Manifest.toml")
+                deps = manifest["deps"]
+                @test only(deps["DataStructures"])["version"] == "0.18.1"
+                @test only(deps["LocalA"])["path"] == "LocalA"
+                @test Set(only(deps["LocalA"])["deps"]) == Set(["DataStructures", "LocalB"])
+                @test only(deps["LocalB"])["path"] == "LocalB"
+                @test only(deps["LocalB"])["deps"] == ["DataStructures"]
+                run(`$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
+
+                restored = TOML.parsefile("Project.toml")
+                @test Set(keys(restored["sources"])) == Set(["LocalA"])
+                @test !haskey(restored["deps"], "LocalB")
+                @test !haskey(restored["deps"], "DataStructures")
             end
         end
     end
@@ -1248,12 +1462,12 @@ end
         end
     end
 
-    @testset "direct path sources reject different compat for a promoted dependency" begin
+    @testset "direct path sources reject disjoint compat for a promoted dependency" begin
         mktempdir() do dir
             cd(dir) do
                 for (name, uuid, constraint) in (
-                        ("LocalA", "44444444-4444-4444-4444-444444444444", "1.9.8"),
-                        ("LocalB", "66666666-6666-6666-6666-666666666666", "1.9.9")
+                        ("LocalA", "44444444-4444-4444-4444-444444444444", "0.12"),
+                        ("LocalB", "66666666-6666-6666-6666-666666666666", "1.9.9"),
                     )
                     mkpath("$name/src")
                     write(
@@ -1316,7 +1530,7 @@ end
                 )
                 wait(process)
                 @test !success(process)
-                @test occursin("different compat entries", String(take!(output)))
+                @test occursin("disjoint compat entries", String(take!(output)))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -972,6 +972,96 @@ end
         end
     end
 
+    @testset "split projects rebase direct path sources in both locked manifests" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalDep/src")
+                write(
+                    "LocalDep/Project.toml",
+                    """
+                    name = "LocalDep"
+                    uuid = "99999999-9999-9999-9999-999999999999"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [compat]
+                    JSON = "0.21"
+                    """
+                )
+                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing JSON\nend\n")
+
+                mkpath("src")
+                mkpath("test")
+                write("src/RootPkg.jl", "module RootPkg\nusing LocalDep\nend\n")
+                write(
+                    "test/runtests.jl",
+                    "using Test, BenchmarkTools, RootPkg\n@test true\n"
+                )
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    LocalDep = "99999999-9999-9999-9999-999999999999"
+
+                    [sources]
+                    LocalDep = {path = "LocalDep"}
+
+                    [compat]
+                    julia = "1.10"
+                    JSON = "0.21.4"
+                    LocalDep = "0.1"
+                    """
+                )
+                write(
+                    "test/Project.toml",
+                    """
+                    [deps]
+                    BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+                    RootPkg = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+                    [sources]
+                    RootPkg = {path = ".."}
+
+                    [compat]
+                    BenchmarkTools = "1.5.0"
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" ".,test" "alldeps" "1"`)
+
+                main_manifest = TOML.parsefile("Manifest.toml")
+                test_manifest = TOML.parsefile("test/Manifest.toml")
+                main_deps = main_manifest["deps"]
+                test_deps = test_manifest["deps"]
+                @test only(main_deps["JSON"])["version"] == "0.21.4"
+                @test only(main_deps["BenchmarkTools"])["version"] == "1.5.0"
+                @test only(main_deps["LocalDep"])["path"] == "LocalDep"
+                @test Set(only(main_deps["LocalDep"])["deps"]) == Set(["JSON"])
+                @test only(test_deps["LocalDep"])["path"] == "../LocalDep"
+                @test only(main_deps["RootPkg"])["path"] == "."
+                @test only(test_deps["RootPkg"])["path"] == ".."
+                @test Set(only(test_deps["RootPkg"])["deps"]) == Set(["JSON", "LocalDep"])
+
+                locked = Dict(
+                    name => only(test_deps[name])["version"]
+                    for name in ("BenchmarkTools", "JSON")
+                )
+                run(`$(Base.julia_cmd()) --project=test -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'`)
+                after = TOML.parsefile("test/Manifest.toml")["deps"]
+                @test locked == Dict(
+                    name => only(after[name])["version"] for name in keys(locked)
+                )
+            end
+        end
+    end
+
     @testset "no_promote keeps a named weakdep extension out of the joint resolve" begin
         # The merged resolution promotes every weakdep test-extra into ONE joint
         # floor-resolve -- correct, because the extensions coexist in a single test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -972,6 +972,121 @@ end
         end
     end
 
+    @testset "direct path-source runtime dependencies participate in minimum resolution" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalA/src")
+                write(
+                    "LocalA/Project.toml",
+                    """
+                    name = "LocalA"
+                    uuid = "11111111-1111-1111-1111-111111111111"
+                    version = "0.1.0"
+
+                    [deps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+                    [compat]
+                    DataStructures = "0.18"
+                    julia = "1.10"
+                    JSON = "0.21"
+                    StaticArrays = "1.9.8"
+                    """
+                )
+                write(
+                    "LocalA/src/LocalA.jl",
+                    "module LocalA\nusing DataStructures, JSON, StaticArrays\nend\n"
+                )
+
+                mkpath("LocalB/src")
+                write(
+                    "LocalB/Project.toml",
+                    """
+                    name = "LocalB"
+                    uuid = "22222222-2222-2222-2222-222222222222"
+                    version = "0.1.0"
+
+                    [deps]
+                    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+                    [compat]
+                    julia = "1.10"
+                    StaticArrays = "1.9.8"
+                    """
+                )
+                write("LocalB/src/LocalB.jl", "module LocalB\nusing StaticArrays\nend\n")
+
+                mkpath("src")
+                mkpath("test")
+                write("src/RootPkg.jl", "module RootPkg\nusing LocalA, LocalB\nend\n")
+                write(
+                    "test/runtests.jl",
+                    "using Test, BenchmarkTools, RootPkg\n@test true\n"
+                )
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "33333333-3333-3333-3333-333333333333"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    LocalA = "11111111-1111-1111-1111-111111111111"
+                    LocalB = "22222222-2222-2222-2222-222222222222"
+
+                    [sources]
+                    LocalA = {path = "LocalA"}
+                    LocalB = {path = "LocalB"}
+
+                    [compat]
+                    DataStructures = "0.18.0"
+                    julia = "1.10"
+                    BenchmarkTools = "1.5.0"
+                    JSON = "0.21.4"
+                    LocalA = "0.1"
+                    LocalB = "0.1"
+
+                    [weakdeps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [extras]
+                    BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+                    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+                    [targets]
+                    test = ["BenchmarkTools", "Test"]
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "alldeps" "1"`)
+
+                manifest = TOML.parsefile("Manifest.toml")
+                deps = manifest["deps"]
+                @test only(deps["DataStructures"])["version"] == "0.18.0"
+                @test only(deps["StaticArrays"])["version"] == "1.9.8"
+                @test only(deps["JSON"])["version"] == "0.21.4"
+                @test only(deps["BenchmarkTools"])["version"] == "1.5.0"
+                local_a = only(deps["LocalA"])
+                local_b = only(deps["LocalB"])
+                @test local_a["path"] == "LocalA"
+                @test Set(local_a["deps"]) ==
+                      Set(["DataStructures", "JSON", "StaticArrays"])
+                @test local_b["path"] == "LocalB"
+                @test Set(local_b["deps"]) == Set(["StaticArrays"])
+                run(`$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
+
+                restored = TOML.parsefile("Project.toml")
+                @test Set(keys(restored["sources"])) == Set(["LocalA", "LocalB"])
+                @test haskey(restored["weakdeps"], "DataStructures")
+                @test !haskey(restored["deps"], "DataStructures")
+                @test !haskey(restored["deps"], "StaticArrays")
+            end
+        end
+    end
+
     @testset "split projects rebase direct path sources in both locked manifests" begin
         mktempdir() do dir
             cd(dir) do
@@ -984,13 +1099,13 @@ end
                     version = "0.1.0"
 
                     [deps]
-                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
                     [compat]
-                    JSON = "0.21"
+                    StaticArrays = "1.9.8"
                     """
                 )
-                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing JSON\nend\n")
+                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing StaticArrays\nend\n")
 
                 mkpath("src")
                 mkpath("test")
@@ -1040,10 +1155,10 @@ end
                 test_manifest = TOML.parsefile("test/Manifest.toml")
                 main_deps = main_manifest["deps"]
                 test_deps = test_manifest["deps"]
+                @test only(main_deps["StaticArrays"])["version"] == "1.9.8"
                 @test only(main_deps["JSON"])["version"] == "0.21.4"
                 @test only(main_deps["BenchmarkTools"])["version"] == "1.5.0"
                 @test only(main_deps["LocalDep"])["path"] == "LocalDep"
-                @test Set(only(main_deps["LocalDep"])["deps"]) == Set(["JSON"])
                 @test only(test_deps["LocalDep"])["path"] == "../LocalDep"
                 @test only(main_deps["RootPkg"])["path"] == "."
                 @test only(test_deps["RootPkg"])["path"] == ".."
@@ -1051,13 +1166,157 @@ end
 
                 locked = Dict(
                     name => only(test_deps[name])["version"]
-                    for name in ("BenchmarkTools", "JSON")
+                    for name in ("BenchmarkTools", "JSON", "StaticArrays")
                 )
                 run(`$(Base.julia_cmd()) --project=test -e 'using Pkg; Pkg.instantiate(); include("test/runtests.jl")'`)
                 after = TOML.parsefile("test/Manifest.toml")["deps"]
                 @test locked == Dict(
                     name => only(after[name])["version"] for name in keys(locked)
                 )
+            end
+        end
+    end
+
+    @testset "locked tests reject an incompatible root-owned path dependency floor" begin
+        mktempdir() do dir
+            cd(dir) do
+                mkpath("LocalDep/src")
+                write(
+                    "LocalDep/Project.toml",
+                    """
+                    name = "LocalDep"
+                    uuid = "77777777-7777-7777-7777-777777777777"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [compat]
+                    JSON = "0.20"
+                    """
+                )
+                write("LocalDep/src/LocalDep.jl", "module LocalDep\nusing JSON\nend\n")
+
+                mkpath("src")
+                mkpath("test")
+                write("src/RootPkg.jl", "module RootPkg\nusing LocalDep\nend\n")
+                write("test/runtests.jl", "using Test, RootPkg\n@test true\n")
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "88888888-8888-8888-8888-888888888888"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+                    LocalDep = "77777777-7777-7777-7777-777777777777"
+
+                    [sources]
+                    LocalDep = {path = "LocalDep"}
+
+                    [compat]
+                    julia = "1.10"
+                    JSON = "=0.21.4"
+                    LocalDep = "0.1"
+
+                    [extras]
+                    Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+                    [targets]
+                    test = ["Test"]
+                    """
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`)
+                manifest = TOML.parsefile("Manifest.toml")
+                @test only(manifest["deps"]["JSON"])["version"] == "0.21.4"
+
+                output = IOBuffer()
+                process = run(
+                    pipeline(
+                        `$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`;
+                        stdout = output, stderr = output
+                    ); wait = false
+                )
+                wait(process)
+                log = String(take!(output))
+                @test !success(process)
+                @test occursin("JSON", log)
+                @test occursin("compat", lowercase(log)) || occursin("0.20", log)
+            end
+        end
+    end
+
+    @testset "direct path sources reject different compat for a promoted dependency" begin
+        mktempdir() do dir
+            cd(dir) do
+                for (name, uuid, constraint) in (
+                        ("LocalA", "44444444-4444-4444-4444-444444444444", "1.9.8"),
+                        ("LocalB", "66666666-6666-6666-6666-666666666666", "1.9.9")
+                    )
+                    mkpath("$name/src")
+                    write(
+                        "$name/Project.toml",
+                        """
+                        name = "$name"
+                        uuid = "$uuid"
+                        version = "0.1.0"
+
+                        [deps]
+                        StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+                        [compat]
+                        StaticArrays = "$constraint"
+                        """
+                    )
+                    write("$name/src/$name.jl", "module $name\nend\n")
+                end
+                mkdir("test")
+                write(
+                    "Project.toml",
+                    """
+                    name = "RootPkg"
+                    uuid = "55555555-5555-5555-5555-555555555555"
+                    version = "0.1.0"
+
+                    [deps]
+                    LocalA = "44444444-4444-4444-4444-444444444444"
+
+                    [sources]
+                    LocalA = {path = "LocalA"}
+
+                    [compat]
+                    julia = "1.10"
+                    LocalA = "0.1"
+                    """
+                )
+                write(
+                    "test/Project.toml",
+                    """
+                    [deps]
+                    LocalB = "66666666-6666-6666-6666-666666666666"
+                    RootPkg = "55555555-5555-5555-5555-555555555555"
+
+                    [sources]
+                    LocalB = {path = "../LocalB"}
+                    RootPkg = {path = ".."}
+
+                    [compat]
+                    LocalB = "0.1"
+                    """
+                )
+
+                output = IOBuffer()
+                process = run(
+                    pipeline(
+                        `$(Base.julia_cmd()) $downgrade_jl "" ".,test" "deps" "1.10"`;
+                        stdout = output, stderr = output
+                    ); wait = false
+                )
+                wait(process)
+                @test !success(process)
+                @test occursin("different compat entries", String(take!(output)))
             end
         end
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1678,7 +1678,15 @@ end
                     """
                 )
 
-                run(`$(Base.julia_cmd()) $downgrade_jl "" ".,test" "deps" "1.10"`)
+                # Resolve for the running Julia rather than a fixed target. The
+                # serializer runs during the merge, before the resolver, so the
+                # target is irrelevant to what this checks; matching it to the
+                # runtime keeps resolution single-runtime. DataStructures 0.18.0
+                # resolved for an older target from a newer runtime otherwise pulls
+                # a stdlib JLL absent from the newer depot -- the action's
+                # documented cross-runtime fragility, unrelated to compat serializing.
+                target = string(VERSION.major, '.', VERSION.minor)
+                run(`$(Base.julia_cmd()) $downgrade_jl "" ".,test" "deps" $target`)
 
                 @test isfile("Manifest.toml")
                 manifest = TOML.parsefile("Manifest.toml")


### PR DESCRIPTION
## Summary

- follow active local path sources recursively and include their hard registry dependencies in the minimum-version resolution
- intersect path-source compat requirements with root-owned constraints and fail early on disjoint ranges
- reconstruct complete path entries in the locked manifests, including hard dependencies, weak dependencies, and extension triggers
- preserve test-only path-source floors during locked `Pkg.test` sandboxes without making the path packages runtime dependencies on Julia 1.11+
- retain the Julia 1.10 fallback required for test-only path sources, whose `[sources]` entries that runtime does not honor in `Pkg.test`

## Why

The released `julia-actions/julia-downgrade-compat@v2` removes local `[sources]` packages before Resolver.jl computes minimum versions, then appends them to the manifest afterward. Unique transitive constraints from those packages therefore do not participate in resolution. Recursive local packages can also be left with missing manifest dependencies or incomplete extension metadata.

OrdinaryDiffEq#3917 makes `NonlinearSolveBase = "2.34.1"` a direct requirement of the in-tree `OrdinaryDiffEqNonlinearSolve` package. The released action still selected `NonlinearSolveBase 2.33.0`, because that local package's constraints were invisible to the resolver. This change makes the declaration effective at its source instead of copying transitive floors into every consumer or adding reconciliation logic to SciML's shared workflow.

There is a separate Pkg sandbox issue for packages used only through `[targets].test`: even when the action's manifest contains the correct minimum version, Julia 1.11+ can independently resolve that local package's dependency graph when `Pkg.test` builds its sandbox. `allow_reresolve=false` and a pinned manifest entry do not prevent the upgrade. Adding the dependency only to `[extras]`/`[targets].test` also does not prevent it. Making the hard non-local dependency visible in root `[deps]` does preserve the locked version, so the action now performs that minimal anchor promotion in its disposable checkout. The local path package remains a test dependency.

Weak-only path test sources are added to `[extras]` for Pkg validation but retain `[weakdeps]` on Julia 1.11+. Julia 1.10 and earlier instead require the path packages themselves in `[deps]`, because their test sandbox ignores `[sources]`. These checkout mutations are intentional and documented.

## Validation

- focused Julia 1.11 sandbox reproduction:
  - action resolution selected `DataStructures 0.18.0`
  - the unanchored locked test selected `0.18.22` and failed
  - `pinned = true` and an extras-only anchor remained ineffective
  - a root dependency anchor retained `0.18.0`, passed the locked test, and left the manifest hash unchanged
- Julia 1.10.11 full action suite: **162/162 passed** in 13m37.9s
- Julia 1.11.9 full action suite: **166/166 passed** in 19m24.7s
- Julia 1.12.6 full action suite: **166/166 passed** in 17m34.5s
- `git diff --check` passed; `downgrade.jl` and `test/runtests.jl` parsed on Julia 1.10, 1.11, and 1.12
- exact OrdinaryDiffEq#3917 action replay selected:
  - `MuladdMacro 0.2.4`
  - `SciMLOperators 1.24.3`
  - `NonlinearSolveBase 2.34.1`
  - `NonlinearSolve 4.20.3`
  - `LinearSolve 4.3.0`
- exact OrdinaryDiffEq locked `Pkg.test(; allow_reresolve=false)`:
  - all 27 `InterfaceI` testsets completed and Pkg reported `OrdinaryDiffEq tests passed`
  - the suite retained its 7 pre-existing broken/skipped assertions; this change did not add or alter any bypass
  - completed in 1763.8 seconds with the Project and Manifest SHA-256 hashes unchanged
- exact OrdinaryDiffEq locked `Pkg.build()`:
  - exited 0 after successfully precompiling 400 dependencies in 464 seconds
  - retained the same five versions and left both Project and Manifest SHA-256 hashes unchanged

## Stack

This is stacked on #55, which is stacked on #54. Together they supersede the repository-specific workaround in SciML/.github#118.

Closes #38.
Closes #39.

Please ignore this draft until it has been reviewed by @ChrisRackauckas.
