### PR TITLE
Lock old-style test dependency floors through Pkg.test

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,27 @@ locked build and test steps.
 
 This support does not promote path-package weak dependencies.
 
+### Old-style test dependencies
+
+A package that declares its test dependencies with `[extras]`/`[weakdeps]` and
+`[targets].test`, rather than a `test/Project.toml`, has no environment of its
+own for `Pkg.test` to lock. Pkg instead synthesizes a sandbox project from
+`[deps]` plus the `[targets].test` names and resolves that, which discards the
+minimum this action resolved for a name reachable only through `[extras]` or
+`[weakdeps]` and installs the newest compatible version in its place — even with
+`allow_reresolve: false`. The downgrade job then passes against versions it never
+meant to test.
+
+The action therefore promotes each floor-resolved test extra to `[deps]` in the
+checkout, so those names are on the path `Pkg.test` preserves. A promoted name
+that was a weak dependency is removed from `[weakdeps]`, since Pkg does not
+accept it in both tables; its `[extensions]` entry is untouched and the
+extension still loads. Only names the resolution actually placed in the manifest
+are promoted, so `no_promote` entries and stdlibs are left alone.
+
+Like the path-source promotions above, this intentionally leaves `Project.toml`
+modified for subsequent locked build and test steps.
+
 ## Downgrade Modes
 
 - **`deps`**: Minimize only your direct dependencies (recommended for most packages)

--- a/downgrade.jl
+++ b/downgrade.jl
@@ -301,6 +301,109 @@ function prepare_test_target_path_sources!(
 end
 
 """
+    registry_backed_manifest_entries(manifest_file) -> Dict{String, String}
+
+Map package name to uuid for every manifest entry that came from the registry,
+i.e. that carries both a resolved `version` and a `git-tree-sha1`. Stdlibs
+(no tree hash) and path/url entries (no version, or sourced in-tree) are
+excluded, so this is exactly the set of names holding a resolved floor.
+"""
+function registry_backed_manifest_entries(manifest_file::String)
+    entries = Dict{String, String}()
+    isfile(manifest_file) || return entries
+    manifest = TOML.parsefile(manifest_file)
+    # ≥1.7 manifests nest the package tables under `deps`; ≤1.6 manifests put
+    # them at the top level next to metadata scalars like `julia_version`.
+    deps = get(manifest, "deps", manifest)
+    for (name, stanzas) in deps
+        stanzas isa AbstractVector || continue
+        length(stanzas) == 1 || continue
+        entry = only(stanzas)
+        entry isa AbstractDict || continue
+        haskey(entry, "version") && haskey(entry, "git-tree-sha1") || continue
+        uuid = get(entry, "uuid", nothing)
+        uuid === nothing || (entries[name] = uuid)
+    end
+    return entries
+end
+
+"""
+    promote_test_target_registry_deps!(project_file, manifest_file) -> Vector{String}
+
+Promote registry-backed `[targets].test` dependencies into runtime `[deps]` and
+return the names promoted.
+
+`Pkg.test` does not run in the project environment. For an old-style layout it
+synthesizes a sandbox project out of `[deps]` plus the `[targets].test` names and
+resolves that, and a floor this action wrote to the manifest for a name reachable
+only through `[extras]`/`[weakdeps]` does not survive into the sandbox: the
+sandbox installs the newest compatible version instead, so the downgrade job
+tests versions it never meant to test and reports a false pass. Listing those
+names in `[deps]` puts them on the path `Pkg.test` does preserve.
+
+Only names the resolution actually placed in `manifest_file` as registry
+packages are promoted. That skips `no_promote` entries (deliberately left out of
+the joint floor-resolve, so they have no floor to keep) and stdlibs, and it keeps
+the project from declaring a dependency the locked manifest cannot satisfy.
+Path- and url-sourced names are left to `prepare_test_target_path_sources!`.
+"""
+function promote_test_target_registry_deps!(project_file::String, manifest_file::String)
+    project = TOML.parsefile(project_file)
+    test_target = get(get(project, "targets", Dict{String, Any}()), "test", String[])
+    isempty(test_target) && return String[]
+
+    deps = get(project, "deps", Dict{String, Any}())
+    extras = get(project, "extras", Dict{String, Any}())
+    weakdeps = get(project, "weakdeps", Dict{String, Any}())
+    sources = get(project, "sources", Dict{String, Any}())
+    resolved = registry_backed_manifest_entries(manifest_file)
+
+    promoted = String[]
+    for name in sort!(unique(String.(test_target)))
+        haskey(deps, name) && continue
+        haskey(sources, name) && continue
+
+        # `Pkg` resolves a test target through [extras] first, then [weakdeps].
+        uuid = get(extras, name, nothing)
+        weak_uuid = get(weakdeps, name, nothing)
+        if uuid === nothing
+            uuid = weak_uuid
+            uuid === nothing && continue
+        elseif weak_uuid !== nothing && weak_uuid != uuid
+            error(
+                "Test-target dependency $name has uuid $uuid in [extras], " *
+                    "but $weak_uuid in [weakdeps]"
+            )
+        end
+
+        resolved_uuid = get(resolved, name, nothing)
+        resolved_uuid === nothing && continue
+        resolved_uuid == uuid || error(
+            "Test-target dependency $name has uuid $uuid in $project_file, " *
+                "but $resolved_uuid in $manifest_file"
+        )
+        push!(promoted, name)
+    end
+    isempty(promoted) && return promoted
+
+    deps = get!(project, "deps", Dict{String, Any}())
+    for name in promoted
+        deps[name] = get(extras, name, get(weakdeps, name, nothing))
+        # A name cannot sit in both [deps] and [weakdeps]. Dropping it here
+        # matches what the merged project already did for the resolve, and the
+        # extension it triggers stays declared in [extensions] and still loads.
+        delete!(weakdeps, name)
+    end
+    isempty(weakdeps) && delete!(project, "weakdeps")
+
+    open(project_file, "w") do io
+        TOML.print(io, project)
+    end
+    @info "Promoted old-style test dependencies into [deps] for locked Pkg.test" promoted
+    return promoted
+end
+
+"""
     collect_path_sources(project_file; include_test_target = true) -> Vector{DirectPathSource}
 
 Collect local path packages that occur in `[sources]` and are active as runtime
@@ -985,6 +1088,7 @@ function resolve_directory(
                         project_file; no_promote
                     )
                 )
+                promote_test_target_registry_deps!(project_file, manifest_file)
                 add_main_package_to_manifest(manifest_file, project_file; path = ".")
                 if !isempty(source_pkgs)
                     add_source_packages_to_manifest(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -431,6 +431,186 @@ end
         end
     end
 
+    @testset "old-style test deps keep their floor inside Pkg.test" begin
+        # Writing the floor to the manifest is not enough for an old-style layout:
+        # Pkg.test builds a sandbox project out of [deps] plus [targets].test and
+        # resolves that, which drops a floor held only for an [extras] name and
+        # installs the newest compatible version instead -- a green downgrade job
+        # that never ran against the minimum. Promoting the resolved test extras
+        # into [deps] puts them on the path Pkg.test preserves.
+        write_repro() = begin
+            write(
+                "Project.toml",
+                """
+                name = "ReproPkg"
+                uuid = "598b003f-0677-49cf-8d2a-39b1658b755a"
+                version = "0.1.0"
+
+                [deps]
+                JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                [extras]
+                DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+                Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+                [targets]
+                test = ["DataStructures", "Test"]
+
+                [compat]
+                julia = "1.10"
+                JSON = "0.20, 0.21"
+                DataStructures = "0.17, 0.18"
+                """,
+            )
+            mkdir("src")
+            write("src/ReproPkg.jl", "module ReproPkg\nend\n")
+            mkdir("test")
+            write(
+                "test/runtests.jl",
+                """
+                using ReproPkg, DataStructures, Test
+                println("SANDBOX_DATASTRUCTURES=", pkgversion(DataStructures))
+                @test true
+                """,
+            )
+        end
+
+        mktempdir() do dir
+            cd(dir) do
+                write_repro()
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`)
+
+                project = TOML.parsefile("Project.toml")
+                @test startswith(
+                    TOML.parsefile("Manifest.toml")["deps"]["DataStructures"][1]["version"],
+                    "0.17",
+                )
+                # The extra is promoted; the stdlib in the same target has no floor
+                # to keep and must be left alone.
+                @test haskey(project["deps"], "DataStructures")
+                @test !haskey(project["deps"], "Test")
+                @test project["deps"]["DataStructures"] == project["extras"]["DataStructures"]
+                # The hash is written after the promotion, so the locked manifest
+                # still matches the project Pkg.test will read.
+                @test TOML.parsefile("Manifest.toml")["project_hash"] ==
+                    expected_project_hash(joinpath(dir, "Project.toml"))
+
+                manifest_before = read("Manifest.toml", String)
+                # Pkg wires the sandboxed test process's stdio to stderr, so both
+                # streams have to be captured to see what the tests printed.
+                captured = IOBuffer()
+                run(
+                    pipeline(
+                        `$(Base.julia_cmd()) --project=. -e "using Pkg; Pkg.test(allow_reresolve=false)"`;
+                        stdout = captured, stderr = captured,
+                    ),
+                )
+                output = String(take!(captured))
+                @test occursin("SANDBOX_DATASTRUCTURES=0.17", output)
+                @test read("Manifest.toml", String) == manifest_before
+            end
+        end
+    end
+
+    @testset "no_promote test extras are not promoted into [deps]" begin
+        # An extra kept out of the joint floor-resolve has no floor in the manifest,
+        # so promoting it would declare a dependency the locked manifest cannot
+        # satisfy. Manifest membership is what gates the promotion.
+        mktempdir() do dir
+            cd(dir) do
+                write(
+                    "Project.toml",
+                    """
+                    name = "ReproPkg"
+                    uuid = "598b003f-0677-49cf-8d2a-39b1658b755a"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [extras]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [targets]
+                    test = ["DataStructures"]
+
+                    [compat]
+                    julia = "1.10"
+                    JSON = "0.20, 0.21"
+                    DataStructures = "0.17, 0.18"
+                    """,
+                )
+                mkdir("src")
+                write("src/ReproPkg.jl", "module ReproPkg\nend\n")
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10" "DataStructures"`)
+
+                project = TOML.parsefile("Project.toml")
+                @test !haskey(get(project, "deps", Dict()), "DataStructures")
+                @test haskey(project["extras"], "DataStructures")
+                @test !haskey(TOML.parsefile("Manifest.toml")["deps"], "DataStructures")
+            end
+        end
+    end
+
+    @testset "promoted weakdep test extra leaves [weakdeps] and still loads" begin
+        # A test extra that is also a weakdep cannot stay in both tables, so the
+        # promotion drops it from [weakdeps]. Its [extensions] entry keeps naming
+        # it, and Pkg must still build the environment and the extension.
+        mktempdir() do dir
+            cd(dir) do
+                write(
+                    "Project.toml",
+                    """
+                    name = "ExtPkg"
+                    uuid = "0f4b8c11-3f1e-4d2a-9b77-1a2b3c4d5e6f"
+                    version = "0.1.0"
+
+                    [deps]
+                    JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+
+                    [weakdeps]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [extensions]
+                    ExtPkgDSExt = "DataStructures"
+
+                    [extras]
+                    DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+
+                    [targets]
+                    test = ["DataStructures"]
+
+                    [compat]
+                    julia = "1.10"
+                    JSON = "0.20, 0.21"
+                    DataStructures = "0.17, 0.18"
+                    """,
+                )
+                mkdir("src")
+                write("src/ExtPkg.jl", "module ExtPkg\nend\n")
+                mkdir("ext")
+                write(
+                    "ext/ExtPkgDSExt.jl",
+                    "module ExtPkgDSExt\nusing ExtPkg, DataStructures\nend\n",
+                )
+
+                run(`$(Base.julia_cmd()) $downgrade_jl "" "." "deps" "1.10"`)
+
+                project = TOML.parsefile("Project.toml")
+                @test haskey(project["deps"], "DataStructures")
+                @test !haskey(get(project, "weakdeps", Dict()), "DataStructures")
+                @test project["extensions"]["ExtPkgDSExt"] == "DataStructures"
+
+                output = read(
+                    `$(Base.julia_cmd()) --project=. -e "using Pkg; Pkg.instantiate(); using ExtPkg, DataStructures; println(\"LOADED=\", pkgversion(DataStructures))"`,
+                    String,
+                )
+                @test occursin("LOADED=0.17", output)
+            end
+        end
+    end
+
     @testset "single project with [sources] path dep used in [targets]" begin
         # Regression test: a package that devs a sibling via [sources] and also
         # lists it as a test dependency in [targets]. The source package must be
@@ -1236,8 +1416,11 @@ end
                     Set(["DataStructures", "JSON", "Preferences", "StaticArrays"])
                 @test local_b["path"] == "LocalB"
                 @test Set(local_b["deps"]) == Set(["Preferences", "StaticArrays"])
+                # BenchmarkTools is a floor-resolved [targets].test extra, so it is
+                # promoted into [deps] to survive the Pkg.test sandbox and shows up
+                # in the root's manifest stanza alongside the declared deps.
                 @test Set(only(deps["RootPkg"])["deps"]) ==
-                    Set(["JSON", "LocalA", "LocalB"])
+                    Set(["JSON", "LocalA", "LocalB", "BenchmarkTools"])
                 run(`$(Base.julia_cmd()) --project=. -e 'using Pkg; Pkg.test(; allow_reresolve = false)'`)
 
                 restored = TOML.parsefile("Project.toml")
@@ -1246,6 +1429,7 @@ end
                 @test !haskey(restored["deps"], "DataStructures")
                 @test !haskey(restored["deps"], "Preferences")
                 @test !haskey(restored["deps"], "StaticArrays")
+                @test haskey(restored["deps"], "BenchmarkTools")
             end
         end
     end


### PR DESCRIPTION
> **Ignore this PR until it has been reviewed by @ChrisRackauckas.**

## Problem

For an old-style layout — test dependencies declared with `[extras]`/`[weakdeps]` plus `[targets].test`, and no `test/Project.toml` — the floors this action resolves are silently discarded before the tests run.

The action's merged resolution folds `[extras]` into the merged `[deps]`, min-resolves, and writes the floors to the project's `Manifest.toml`. But `Pkg.test` does not run in the project environment. For an old-style layout it synthesizes a sandbox project from `[deps]` plus the `[targets].test` names (`Pkg.Operations.gen_target_project`) and resolves that. A floor held only for a name reachable through `[extras]`/`[weakdeps]` does not survive into the sandbox, so the sandbox installs the newest compatible version instead — and `allow_reresolve: false` does not prevent it.

The downgrade job then reports green against versions it never tested.

Deterministic reproduction, on unmodified `main`:

```toml
name = "ReproPkg"
uuid = "598b003f-0677-49cf-8d2a-39b1658b755a"
version = "0.1.0"

[deps]
JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"

[extras]
DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

[targets]
test = ["DataStructures", "Test"]

[compat]
julia = "1.10"
JSON = "0.20, 0.21"
DataStructures = "0.17, 0.18"
```

```
$ julia downgrade.jl "" "." "deps" "1.10" ""
$ grep -A4 'deps.DataStructures' Manifest.toml     # version = "0.17.0"
$ julia --project=. -e 'using Pkg; Pkg.test(allow_reresolve=false)'
SANDBOX_DATASTRUCTURES_VERSION=0.18.22
```

Observed on Julia 1.10.11 and 1.12.6.

## Change

`promote_test_target_registry_deps!` promotes each floor-resolved `[targets].test` name into the checkout's `[deps]` after the merged resolution, putting those names on the path `Pkg.test` preserves. This is the same technique `prepare_test_target_path_sources!` already applies to test-only *path* sources, for the same reason, extended to registry-backed extras.

- Manifest membership gates the promotion. Only names the resolution actually placed in the manifest as registry packages (a `version` **and** a `git-tree-sha1`) are promoted. That is what makes `no_promote` work without re-deriving its rules: a `no_promote` name is deliberately kept out of the joint floor-resolve, so it has no manifest entry and no floor to preserve. Stdlibs are skipped for the same reason, and the project never ends up declaring a dependency the locked manifest cannot satisfy.
- `[sources]` names are skipped and left to `prepare_test_target_path_sources!`.
- Test targets are resolved through `[extras]` then `[weakdeps]`, matching `gen_target_project`. A promoted weakdep is removed from `[weakdeps]` (Pkg does not accept a name in both tables); its `[extensions]` entry is untouched and the extension still precompiles and loads.
- UUID disagreement between `[extras]`, `[weakdeps]`, and the manifest is an error rather than a silent mismatch.
- Runs before `set_manifest_project_hash`, so the hash is computed over the promoted project and the locked manifest still matches what `Pkg.test` reads.
- New-style `test/Project.toml` layouts are untouched: `Pkg.test` uses that environment and ignores `[targets].test`, so there is nothing to promote.

## Verification

Reproduction above, rerun with this branch on both supported Julia lines:

- Julia 1.10.11 — sandbox reports `SANDBOX_DATASTRUCTURES_VERSION=0.17.0`
- Julia 1.12.6 — sandbox reports `SANDBOX_DATASTRUCTURES_VERSION=0.17.0`, and `Manifest.toml` is byte-identical (same md5) before and after `Pkg.test`

`Test`, the stdlib in the same `[targets].test`, is correctly left out of `[deps]`.

Extension-trigger promotion was checked separately on 1.10.11 and 1.12.6: with the trigger moved from `[weakdeps]` to `[deps]` and `[extensions]` unchanged, Pkg precompiles `ExtPkg → ExtPkgJSONExt` and instantiation succeeds on both.

Three testsets added to `test/runtests.jl`:

- `old-style test deps keep their floor inside Pkg.test` — end-to-end: runs the script, asserts the extra is promoted and the stdlib is not, asserts `project_hash` matches the promoted project, then runs `Pkg.test(allow_reresolve=false)` and asserts the sandbox observed 0.17 and left the manifest unchanged.
- `no_promote test extras are not promoted into [deps]` — a `no_promote` name has no manifest entry and stays out of `[deps]`.
- `promoted weakdep test extra leaves [weakdeps] and still loads` — the promoted trigger leaves `[weakdeps]`, `[extensions]` still names it, and the environment instantiates and loads at the floor.

Full `test/runtests.jl` locally, matching CI's `1.10` and `1` matrix:

- Julia 1.10.11 — 179 passed, 0 failed (15m06s)
- Julia 1.12.6 — 183 passed, 0 failed (17m08s)

(The `ERROR:` lines in those logs come from the intentional-failure testsets `invalid cases` and `unknown alias rejected`, same as on unmodified `main`.)

## Known gap (follow-up, not this PR)

A `[targets].test` name that lives **only** in `[weakdeps]` — no `[extras]` entry — never gets a floor in the first place. `create_merged_project` folds only `[extras]` into the merged `[deps]`, so such a name is absent from the resolved manifest even under `mode: alldeps`, and this promotion correctly no-ops on it (promoting it would declare a dependency the manifest cannot satisfy).

Verified: a package with `DataStructures` in `[weakdeps]` + `[targets].test` and no `[extras]` entry resolves with `DataStructures` absent from `Manifest.toml`, and `Pkg.test` runs it at 0.18.22 rather than the 0.17 floor.

Fixing that means folding weakdep-only test targets into the merged resolve, which newly force-min-resolves backends that were previously left at latest — a larger blast radius that belongs in its own PR.

## Context

This supersedes https://github.com/SciML/.github/pull/119, which implements equivalent promotion downstream in SciML's reusable downgrade workflows: ~100 lines of Julia embedded in a bash heredoc, duplicated across two workflow files, with a test that scrapes the heredoc back out of the YAML to check the copies match. Doing it here instead keeps one implementation, reuses `no_promote`/`[sources]` handling rather than re-deriving it, keeps `project_hash` consistent with the promoted project, and benefits every consumer of the action.
